### PR TITLE
feat: add NSStatusItem (menu bar) mode with popover WebView

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
   "scripts": {
     "build": "swiftc -O src/glimpse.swift -o src/glimpse",
     "postinstall": "npm run build",
-    "test": "node test/test.mjs",
+    "test": "node test/test.mjs && node test/test-status-item.mjs",
     "publish:check": "./scripts/publish.sh --dry-run",
     "publish:npm": "./scripts/publish.sh"
   },

--- a/src/glimpse.mjs
+++ b/src/glimpse.mjs
@@ -53,6 +53,9 @@ class GlimpseWindow extends EventEmitter {
         case 'message':
           this.emit('message', msg.data);
           break;
+        case 'click':
+          this.emit('click');
+          break;
         case 'closed':
           if (!this.#closed) {
             this.#closed = true;
@@ -77,6 +80,11 @@ class GlimpseWindow extends EventEmitter {
   #write(obj) {
     if (this.#closed) return;
     this.#proc.stdin.write(JSON.stringify(obj) + '\n');
+  }
+
+  /** @internal — for subclass use only */
+  _write(obj) {
+    this.#write(obj);
   }
 
   send(js) {
@@ -117,12 +125,16 @@ class GlimpseWindow extends EventEmitter {
   }
 }
 
-export function open(html, options = {}) {
+function ensureBinary() {
   if (!existsSync(BINARY)) {
     throw new Error(
       "Glimpse binary not found. Run 'npm run build' or 'swiftc src/glimpse.swift -o src/glimpse'"
     );
   }
+}
+
+export function open(html, options = {}) {
+  ensureBinary();
 
   const args = [];
   if (options.width != null)  args.push('--width',  String(options.width));
@@ -147,6 +159,28 @@ export function open(html, options = {}) {
 
   const proc = spawn(BINARY, args, { stdio: ['pipe', 'pipe', 'inherit'] });
   return new GlimpseWindow(proc, html);
+}
+
+class GlimpseStatusItem extends GlimpseWindow {
+  setTitle(title) {
+    this._write({ type: 'title', title });
+  }
+
+  resize(width, height) {
+    this._write({ type: 'resize', width, height });
+  }
+}
+
+export function statusItem(html, options = {}) {
+  ensureBinary();
+
+  const args = ['--status-item'];
+  if (options.width != null)  args.push('--width',  String(options.width));
+  if (options.height != null) args.push('--height', String(options.height));
+  if (options.title != null)  args.push('--title',  options.title);
+
+  const proc = spawn(BINARY, args, { stdio: ['pipe', 'pipe', 'inherit'] });
+  return new GlimpseStatusItem(proc, html);
 }
 
 export function prompt(html, options = {}) {

--- a/src/glimpse.swift
+++ b/src/glimpse.swift
@@ -135,6 +135,7 @@ struct Config {
     var autoClose: Bool = false
     var cursorAnchor: String? = nil
     var followMode: String = "snap"
+    var statusItem: Bool = false
 }
 
 func parseArgs() -> Config {
@@ -184,6 +185,8 @@ func parseArgs() -> Config {
         case "--follow-mode":
             i += 1
             if i < args.count { config.followMode = args[i] }
+        case "--status-item":
+            config.statusItem = true
         default:
             break
         }
@@ -206,11 +209,46 @@ func parseArgs() -> Config {
     return config
 }
 
+// MARK: - WebView Bridge
+
+let bridgeJS = """
+window.glimpse = {
+    cursorTip: null,
+    send: function(data) {
+        window.webkit.messageHandlers.glimpse.postMessage(JSON.stringify(data));
+    },
+    close: function() {
+        window.webkit.messageHandlers.glimpse.postMessage(JSON.stringify({__glimpse_close: true}));
+    }
+};
+"""
+
 // MARK: - Window Subclass (keyboard support for frameless windows)
 
 class GlimpsePanel: NSWindow {
     override var canBecomeKey: Bool { true }
     override var canBecomeMain: Bool { true }
+}
+
+// MARK: - Status Item View Controller
+
+class StatusItemViewController: NSViewController {
+    let webView: WKWebView
+
+    init(webView: WKWebView, size: NSSize) {
+        self.webView = webView
+        super.init(nibName: nil, bundle: nil)
+        self.preferredContentSize = size
+    }
+
+    required init?(coder: NSCoder) { fatalError() }
+
+    override func loadView() {
+        view = NSView(frame: NSRect(origin: .zero, size: preferredContentSize))
+        webView.frame = view.bounds
+        webView.autoresizingMask = [.width, .height]
+        view.addSubview(webView)
+    }
 }
 
 // MARK: - AppDelegate
@@ -250,26 +288,35 @@ class AppDelegate: NSObject, NSApplicationDelegate, WKNavigationDelegate, WKScri
     let springDt: CGFloat = 1.0 / 120.0
     let springSettleThreshold: CGFloat = 0.5
 
+    // Status item mode
+    var nsStatusItem: NSStatusItem?
+    var popover: NSPopover?
+    var popoverViewController: StatusItemViewController?
+
     nonisolated init(config: Config) {
         self.config = config
     }
 
     func applicationDidFinishLaunching(_ notification: Notification) {
-        hidden = config.hidden
-        cursorAnchor = config.cursorAnchor
-        followMode = config.followMode
-        setupWindow()
-        setupWebView()
-        if config.followCursor {
-            if followMode == "spring" {
-                // Initialize spring position from the window position set by setupWindow()
-                springPosX = window.frame.origin.x
-                springPosY = window.frame.origin.y
-                let target = computeTargetPosition(mouse: NSEvent.mouseLocation)
-                springTargetX = target.x
-                springTargetY = target.y
+        if config.statusItem {
+            setupStatusItem()
+        } else {
+            hidden = config.hidden
+            cursorAnchor = config.cursorAnchor
+            followMode = config.followMode
+            setupWindow()
+            setupWebView()
+            if config.followCursor {
+                if followMode == "spring" {
+                    // Initialize spring position from the window position set by setupWindow()
+                    springPosX = window.frame.origin.x
+                    springPosY = window.frame.origin.y
+                    let target = computeTargetPosition(mouse: NSEvent.mouseLocation)
+                    springTargetX = target.x
+                    springTargetY = target.y
+                }
+                startFollowingCursor()
             }
-            startFollowingCursor()
         }
         startStdinReader()
     }
@@ -331,28 +378,18 @@ class AppDelegate: NSObject, NSApplicationDelegate, WKNavigationDelegate, WKScri
         }
     }
 
-    private func setupWebView() {
+    private func makeWebViewConfiguration() -> WKWebViewConfiguration {
         let ucc = WKUserContentController()
-
-        let bridgeJS = """
-        window.glimpse = {
-            cursorTip: null,
-            send: function(data) {
-                window.webkit.messageHandlers.glimpse.postMessage(JSON.stringify(data));
-            },
-            close: function() {
-                window.webkit.messageHandlers.glimpse.postMessage(JSON.stringify({__glimpse_close: true}));
-            }
-        };
-        """
         let script = WKUserScript(source: bridgeJS, injectionTime: .atDocumentStart, forMainFrameOnly: true)
         ucc.addUserScript(script)
         ucc.add(self, name: "glimpse")
-
         let wkConfig = WKWebViewConfiguration()
         wkConfig.userContentController = ucc
+        return wkConfig
+    }
 
-        webView = WKWebView(frame: window.contentView!.bounds, configuration: wkConfig)
+    private func setupWebView() {
+        webView = WKWebView(frame: window.contentView!.bounds, configuration: makeWebViewConfiguration())
         webView.autoresizingMask = [.width, .height]
         webView.navigationDelegate = self
         if config.transparent {
@@ -363,6 +400,45 @@ class AppDelegate: NSObject, NSApplicationDelegate, WKNavigationDelegate, WKScri
 
         // Load blank page so didFinish fires and we emit "ready"
         webView.loadHTMLString("<html><body></body></html>", baseURL: nil)
+    }
+
+    // MARK: - Status Item
+
+    private func setupStatusItem() {
+        log("Setting up status item mode")
+
+        let size = NSSize(width: config.width, height: config.height)
+        webView = WKWebView(frame: NSRect(origin: .zero, size: size), configuration: makeWebViewConfiguration())
+        webView.navigationDelegate = self
+
+        // Create view controller and popover
+        popoverViewController = StatusItemViewController(webView: webView, size: size)
+
+        popover = NSPopover()
+        popover!.contentViewController = popoverViewController
+        popover!.contentSize = size
+        popover!.behavior = .transient
+
+        // Create status bar item
+        nsStatusItem = NSStatusBar.system.statusItem(withLength: NSStatusItem.variableLength)
+        if let button = nsStatusItem?.button {
+            button.title = config.title == "Glimpse" ? "G" : config.title
+            button.action = #selector(statusItemClicked(_:))
+            button.target = self
+        }
+
+        // Load blank page to trigger first ready
+        webView.loadHTMLString("<html><body></body></html>", baseURL: nil)
+    }
+
+    @objc func statusItemClicked(_ sender: Any?) {
+        guard let button = nsStatusItem?.button, let popover = popover else { return }
+        if popover.isShown {
+            popover.performClose(sender)
+        } else {
+            popover.show(relativeTo: button.bounds, of: button, preferredEdge: .minY)
+        }
+        writeToStdout(["type": "click"])
     }
 
     // MARK: - Follow Cursor
@@ -542,6 +618,10 @@ class AppDelegate: NSObject, NSApplicationDelegate, WKNavigationDelegate, WKScri
             }
             webView.evaluateJavaScript(js, completionHandler: nil)
         case "follow-cursor":
+            guard !config.statusItem else {
+                log("follow-cursor not supported in status-item mode")
+                return
+            }
             let enabled = json["enabled"] as? Bool ?? true
             if let anchor = json["anchor"] as? String, !anchor.isEmpty {
                 cursorAnchor = anchor
@@ -598,21 +678,50 @@ class AppDelegate: NSObject, NSApplicationDelegate, WKNavigationDelegate, WKScri
         case "get-info":
             var info = getSystemInfo()
             info["type"] = "info"
-            if let tip = computeCursorTip() {
+            if !config.statusItem, let tip = computeCursorTip() {
                 info["cursorTip"] = tip
             }
             writeToStdout(info)
         case "show":
-            if let title = json["title"] as? String {
+            if config.statusItem {
+                if let title = json["title"] as? String {
+                    nsStatusItem?.button?.title = title
+                }
+                if let button = nsStatusItem?.button, let popover = popover, !popover.isShown {
+                    popover.show(relativeTo: button.bounds, of: button, preferredEdge: .minY)
+                }
+            } else {
+                if let title = json["title"] as? String {
+                    window.title = title
+                }
+                hidden = false
+                if !config.clickThrough {
+                    NSApp.setActivationPolicy(.regular)
+                }
+                window.makeKeyAndOrderFront(nil)
+                window.makeFirstResponder(webView)
+                NSApp.activate(ignoringOtherApps: true)
+            }
+        case "title":
+            guard let title = json["title"] as? String else {
+                log("title command: missing title field")
+                return
+            }
+            if config.statusItem {
+                nsStatusItem?.button?.title = title
+            } else {
                 window.title = title
             }
-            hidden = false
-            if !config.clickThrough {
-                NSApp.setActivationPolicy(.regular)
+        case "resize":
+            let w = json["width"] as? Int ?? config.width
+            let h = json["height"] as? Int ?? config.height
+            let size = NSSize(width: w, height: h)
+            if config.statusItem {
+                popover?.contentSize = size
+                popoverViewController?.preferredContentSize = size
+            } else {
+                window.setContentSize(size)
             }
-            window.makeKeyAndOrderFront(nil)
-            window.makeFirstResponder(webView)
-            NSApp.activate(ignoringOtherApps: true)
         case "close":
             closeAndExit()
         default:
@@ -621,6 +730,10 @@ class AppDelegate: NSObject, NSApplicationDelegate, WKNavigationDelegate, WKScri
     }
 
     func closeAndExit() {
+        if config.statusItem, let item = nsStatusItem {
+            NSStatusBar.system.removeStatusItem(item)
+            nsStatusItem = nil
+        }
         writeToStdout(["type": "closed"])
         exit(0)
     }
@@ -629,16 +742,18 @@ class AppDelegate: NSObject, NSApplicationDelegate, WKNavigationDelegate, WKScri
 
     nonisolated func webView(_ webView: WKWebView, didFinish navigation: WKNavigation!) {
         MainActor.assumeIsolated {
-            if hidden {
-                // WKWebView loading can implicitly order the window in.
-                // Force it back out after every navigation while hidden.
-                window.orderOut(nil)
-            } else {
-                window.makeFirstResponder(webView)
+            if !config.statusItem {
+                if hidden {
+                    // WKWebView loading can implicitly order the window in.
+                    // Force it back out after every navigation while hidden.
+                    window.orderOut(nil)
+                } else {
+                    window.makeFirstResponder(webView)
+                }
             }
             var info = getSystemInfo()
             info["type"] = "ready"
-            if let tip = computeCursorTip() {
+            if !config.statusItem, let tip = computeCursorTip() {
                 info["cursorTip"] = tip
                 webView.evaluateJavaScript("window.glimpse.cursorTip = {x: \(tip["x"]!), y: \(tip["y"]!)}", completionHandler: nil)
             }
@@ -690,5 +805,5 @@ let config = parseArgs()
 let app = NSApplication.shared
 let delegate = AppDelegate(config: config)
 app.delegate = delegate
-app.setActivationPolicy((config.clickThrough || config.hidden) ? .accessory : .regular)
+app.setActivationPolicy((config.statusItem || config.clickThrough || config.hidden) ? .accessory : .regular)
 app.run()

--- a/test/test-status-item.mjs
+++ b/test/test-status-item.mjs
@@ -1,0 +1,80 @@
+import { statusItem } from '../src/glimpse.mjs';
+
+const TIMEOUT_MS = 10_000;
+
+const HTML = `<!DOCTYPE html>
+<html>
+  <body>
+    <button id="btn" onclick="window.glimpse.send({action:'clicked'})">Click</button>
+  </body>
+</html>`;
+
+function pass(msg) {
+  console.log(`  ✓ ${msg}`);
+}
+
+function fail(msg) {
+  console.error(`  ✗ ${msg}`);
+  process.exit(1);
+}
+
+function waitFor(emitter, event, timeoutMs = TIMEOUT_MS) {
+  return new Promise((resolve, reject) => {
+    const timer = setTimeout(() => {
+      reject(new Error(`Timeout waiting for '${event}' after ${timeoutMs}ms`));
+    }, timeoutMs);
+
+    emitter.once(event, (...args) => {
+      clearTimeout(timer);
+      resolve(args);
+    });
+
+    emitter.once('error', (err) => {
+      clearTimeout(timer);
+      reject(err);
+    });
+  });
+}
+
+console.log('glimpse status-item integration test\n');
+
+let item;
+try {
+  // Step 1: Create status item
+  item = statusItem(HTML, { title: 'TST', width: 300, height: 200 });
+  pass('Status item created');
+
+  // Step 2: Wait for ready
+  await waitFor(item, 'ready');
+  pass('ready event received');
+
+  // Step 3: Eval — click button, verify message round-trip
+  item.send(`document.getElementById('btn').click()`);
+  const [data] = await waitFor(item, 'message');
+  if (data?.action !== 'clicked') {
+    fail(`Expected data.action === 'clicked', got: ${JSON.stringify(data)}`);
+  }
+  pass(`message received: ${JSON.stringify(data)}`);
+
+  // Step 4: setTitle — verify no crash
+  item.setTitle('AP-3');
+  pass('setTitle sent (no crash)');
+
+  // Step 5: resize — verify no crash
+  item.resize(400, 300);
+  pass('resize sent (no crash)');
+
+  // Step 6: Close and verify closed event
+  item.close();
+  pass('Sent close');
+
+  await waitFor(item, 'closed');
+  pass('closed event received');
+
+  console.log('\nAll status-item tests passed');
+  process.exit(0);
+} catch (err) {
+  console.error(`\n  ✗ ${err.message}`);
+  item?.close();
+  process.exit(1);
+}


### PR DESCRIPTION
Adds a menu bar mode to Glimpse. `statusItem()` creates an icon in the macOS status bar that opens a popover with a WKWebView on click. Same protocol, same bridge, just no window.

https://github.com/user-attachments/assets/99af4e5a-9b6a-4e5d-a130-84a6657836b0

The popover auto-closes when clicking outside (`.transient` behavior). `setTitle()` updates the menu bar text dynamically, `resize()` changes the popover dimensions, and a click event fires when the user clicks the icon.

Swift side: `--status-item` flag, `NSStatusItem` + `NSPopover` with a minimal `NSViewController` hosting the WebView. Runs as `.accessory` (no dock icon). Window-only features like `follow-cursor` are ignored.

Existing `open()` and `prompt()` unchanged. Integration test included.
