### PR TITLE
 Support opening HTML links externally in Glimpse

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Unreleased
+
+- **Feature**: Add `openLinks` / `openLinksApp` support so clicked `http`/`https` links in Glimpse can be opened in the system browser or a specific app path.
+
 ## 0.3.7
 
 Companion remembers your preference — disable it once and it stays off across sessions.

--- a/README.md
+++ b/README.md
@@ -172,6 +172,8 @@ const win = open('<html>...</html>', {
 | `followMode` | string | `"snap"` | Follow animation mode: `snap` (instant) or `spring` (iOS-style elastic with overshoot) |
 | `cursorAnchor` | string | `null` | Snap point around cursor: `top-left`, `top-right`, `right`, `bottom-right`, `bottom-left`, `left`. Positions window with a safe zone gap; overrides raw offset positioning. |
 | `cursorOffset` | `{ x?, y? }` | `{ x: 20, y: -20 }` | Pixel offset from cursor (or fine-tuning on top of `cursorAnchor`) |
+| `openLinks` | boolean | `false` | Open clicked `http`/`https` links in the system browser instead of inside Glimpse |
+| `openLinksApp` | string | `null` | Full path to an app bundle to open links with (for example `"/Applications/Google Chrome.app"`) |
 | `hidden` | boolean | `false` | Start the window hidden (prewarm mode) — load HTML in the background, then reveal with `win.show()` |
 | `autoClose` | boolean | `false` | Close the window automatically after the first `message` event |
 
@@ -384,6 +386,8 @@ Available flags:
 | `--cursor-anchor <position>` | — | Snap point around cursor: `top-left`, `top-right`, `right`, `bottom-right`, `bottom-left`, `left` |
 | `--cursor-offset-x N` | `20` | Horizontal offset from cursor (or fine-tuning on top of `--cursor-anchor`) |
 | `--cursor-offset-y N` | `-20` | Vertical offset from cursor (or fine-tuning on top of `--cursor-anchor`) |
+| `--open-links` | off | Open clicked `http`/`https` links in the system default browser |
+| `--open-links-app <path>` | — | Open clicked `http`/`https` links in a specific browser app by full path (for example `"/Applications/Google Chrome.app"`) |
 | `--hidden` | off | Start the window hidden (prewarm mode) — load HTML in background, reveal with `show` command |
 | `--auto-close` | off | Exit after receiving the first message from the page |
 

--- a/bin/glimpse.mjs
+++ b/bin/glimpse.mjs
@@ -28,6 +28,8 @@ for (let i = 0; i < args.length; i++) {
   else if (arg === '--cursor-offset-y' && args[i + 1]) { flags.cursorOffset = { ...flags.cursorOffset, y: parseInt(args[++i]) }; }
   else if (arg === '--cursor-anchor' && args[i + 1]) { flags.cursorAnchor = args[++i]; }
   else if (arg === '--follow-mode' && args[i + 1]) { flags.followMode = args[++i]; }
+  else if (arg === '--open-links') { flags.openLinks = true; }
+  else if (arg === '--open-links-app' && args[i + 1]) { flags.openLinks = true; flags.openLinksApp = args[++i]; }
   else if (!arg.startsWith('-')) { positional.push(arg); }
   else { console.error(`Unknown flag: ${arg}`); process.exit(1); }
 }
@@ -54,6 +56,8 @@ Options:
   --cursor-anchor <pos>  Snap point: top-left, top-right, right, bottom-right, bottom-left, left
   --cursor-offset-x <n>  Cursor X offset (default: 20)
   --cursor-offset-y <n>  Cursor Y offset (default: -20)
+  --open-links          Open http/https links in default browser
+  --open-links-app <app> Open http/https links in a specific browser app (full path)
   --auto-close         Close after first window.glimpse.send()
   --x <n>              Window X position
   --y <n>              Window Y position

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
   "scripts": {
     "build": "swiftc -O src/glimpse.swift -o src/glimpse",
     "postinstall": "npm run build",
-    "test": "node test/test.mjs",
+    "test": "node test/test.mjs && node test/open-links.test.mjs",
     "publish:check": "./scripts/publish.sh --dry-run",
     "publish:npm": "./scripts/publish.sh"
   },

--- a/skills/glimpse/SKILL.md
+++ b/skills/glimpse/SKILL.md
@@ -67,6 +67,8 @@ win.close();                         // close window
   followMode: 'spring',  // 'snap' (instant, default) or 'spring' (elastic)
   cursorAnchor: 'top-right', // snap point: top-left, top-right, right, bottom-right, bottom-left, left
   cursorOffset: {x, y},   // offset from cursor (default: 20, -20)
+  openLinks: true,        // open clicked http/https links in default browser
+  openLinksApp: '/Applications/Google Chrome.app', // optional app bundle path
   autoClose: true,        // close after first message
   x, y,                   // exact screen position
   timeout,                // for prompt() only — ms before rejecting

--- a/src/glimpse.mjs
+++ b/src/glimpse.mjs
@@ -6,7 +6,7 @@ import { dirname, join } from 'node:path';
 import { fileURLToPath } from 'node:url';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
-const BINARY = join(__dirname, 'glimpse');
+const BINARY = process.env.GLIMPSE_BINARY_PATH ?? join(__dirname, 'glimpse');
 
 class GlimpseWindow extends EventEmitter {
   #proc;
@@ -136,6 +136,8 @@ export function open(html, options = {}) {
   if (options.followCursor) args.push('--follow-cursor');
   if (options.hidden)      args.push('--hidden');
   if (options.autoClose)   args.push('--auto-close');
+  if (options.openLinks)   args.push('--open-links');
+  if (options.openLinksApp) args.push('--open-links-app', options.openLinksApp);
 
   if (options.x != null) args.push('--x', String(options.x));
   if (options.y != null) args.push('--y', String(options.y));

--- a/src/glimpse.swift
+++ b/src/glimpse.swift
@@ -135,6 +135,8 @@ struct Config {
     var autoClose: Bool = false
     var cursorAnchor: String? = nil
     var followMode: String = "snap"
+    var openLinks: Bool = false
+    var openLinksApp: String? = nil
 }
 
 func parseArgs() -> Config {
@@ -184,6 +186,14 @@ func parseArgs() -> Config {
         case "--follow-mode":
             i += 1
             if i < args.count { config.followMode = args[i] }
+        case "--open-links":
+            config.openLinks = true
+        case "--open-links-app":
+            i += 1
+            if i < args.count {
+                config.openLinks = true
+                config.openLinksApp = args[i]
+            }
         default:
             break
         }
@@ -249,6 +259,35 @@ class AppDelegate: NSObject, NSApplicationDelegate, WKNavigationDelegate, WKScri
     let springDamping: CGFloat = 28
     let springDt: CGFloat = 1.0 / 120.0
     let springSettleThreshold: CGFloat = 0.5
+
+    private func openURLInBrowser(_ url: URL) {
+        guard config.openLinks else { return }
+
+        if let appPath = config.openLinksApp {
+            let appURL = URL(fileURLWithPath: appPath)
+            guard FileManager.default.fileExists(atPath: appPath) else {
+                log("open-links-app: app path not found: \(appPath)")
+                _ = NSWorkspace.shared.open(url)
+                return
+            }
+
+            let openConfig = NSWorkspace.OpenConfiguration()
+            NSWorkspace.shared.open(
+                [url],
+                withApplicationAt: appURL,
+                configuration: openConfig
+            ) { _, error in
+                if let error {
+                    log("open-links-app: failed to open \(url.absoluteString) in \(appPath): \(error.localizedDescription)")
+                    _ = NSWorkspace.shared.open(url)
+                }
+            }
+        } else {
+            if !NSWorkspace.shared.open(url) {
+                log("open-links: failed to open \(url.absoluteString) in default browser")
+            }
+        }
+    }
 
     nonisolated init(config: Config) {
         self.config = config
@@ -626,6 +665,31 @@ class AppDelegate: NSObject, NSApplicationDelegate, WKNavigationDelegate, WKScri
     }
 
     // MARK: - WKNavigationDelegate
+
+    nonisolated func webView(_ webView: WKWebView, decidePolicyFor navigationAction: WKNavigationAction, decisionHandler: @escaping (WKNavigationActionPolicy) -> Void) {
+        MainActor.assumeIsolated {
+            guard self.config.openLinks else {
+                decisionHandler(.allow)
+                return
+            }
+
+            guard navigationAction.navigationType == .linkActivated else {
+                decisionHandler(.allow)
+                return
+            }
+
+            guard let url = navigationAction.request.url,
+                  let scheme = url.scheme?.lowercased(),
+                  scheme == "http" || scheme == "https"
+            else {
+                decisionHandler(.allow)
+                return
+            }
+
+            openURLInBrowser(url)
+            decisionHandler(.cancel)
+        }
+    }
 
     nonisolated func webView(_ webView: WKWebView, didFinish navigation: WKNavigation!) {
         MainActor.assumeIsolated {

--- a/test/open-links.test.mjs
+++ b/test/open-links.test.mjs
@@ -1,0 +1,108 @@
+import { chmodSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+const APP_PATH = '/Applications/Chrome Debug.app';
+const TIMEOUT_MS = 10_000;
+
+const tmpDir = mkdtempSync(join(tmpdir(), 'glimpse-open-links-'));
+const argsPath = join(tmpDir, 'args.json');
+const mockBinary = join(tmpDir, 'glimpse-mock');
+
+console.log('glimpse open-links flag regression test');
+
+function pass(msg) {
+  console.log(`  ✓ ${msg}`);
+}
+
+function fail(msg) {
+  console.error(`  ✗ ${msg}`);
+  throw new Error(msg);
+}
+
+function waitFor(emitter, event, timeoutMs = TIMEOUT_MS) {
+  return new Promise((resolve, reject) => {
+    const timer = setTimeout(() => {
+      reject(new Error(`Timeout waiting for '${event}' after ${timeoutMs}ms`));
+    }, timeoutMs);
+
+    emitter.once(event, (...args) => {
+      clearTimeout(timer);
+      resolve(args);
+    });
+
+    emitter.once('error', (err) => {
+      clearTimeout(timer);
+      reject(err);
+    });
+  });
+}
+
+function writeMockBinary() {
+  const protocolReady = JSON.stringify({
+    type: 'ready',
+    screen: { width: 800, height: 600, scaleFactor: 1, visibleX: 0, visibleY: 0, visibleWidth: 800, visibleHeight: 600 },
+    screens: [],
+    appearance: { darkMode: false, accentColor: '#000000', reduceMotion: false, increaseContrast: false },
+    cursor: { x: 0, y: 0 },
+  });
+  const scriptLines = [
+    '#!/usr/bin/env node',
+    "const fs = require('node:fs');",
+    "const readline = require('node:readline');",
+    "const argsPath = process.env.GLIMPSE_OPEN_LINKS_ARGS;",
+    "if (argsPath) fs.writeFileSync(argsPath, JSON.stringify(process.argv.slice(2)));",
+    `process.stdout.write(${JSON.stringify(protocolReady)} + '\\n');`,
+    'let sentFinalReady = false;',
+    'const rl = readline.createInterface({ input: process.stdin, crlfDelay: Infinity });',
+    'rl.on("line", (line) => {',
+    '  try {',
+    '    const msg = JSON.parse(line);',
+    '    if (msg?.type === "html" && !sentFinalReady) {',
+    '      process.stdout.write(' + JSON.stringify(protocolReady) + ' + "\\n");',
+    '      sentFinalReady = true;',
+    '    }',
+    '    if (msg?.type === "close") {',
+    '      process.stdout.write(JSON.stringify({ type: "closed" }) + "\\n");',
+    '      process.exit(0);',
+    '    }',
+    '  } catch {',
+    '    // Ignore malformed JSON from this fixture.',
+    '  }',
+    '});',
+  ];
+
+  writeFileSync(mockBinary, scriptLines.join('\n'));
+  chmodSync(mockBinary, 0o755);
+}
+
+async function openMockWindow(options) {
+  const { open } = await import('../src/glimpse.mjs');
+  const win = open('<body><a href="https://example.com">example</a></body>', options);
+  await waitFor(win, 'ready');
+  win.close();
+  await waitFor(win, 'closed');
+  return JSON.parse(readFileSync(argsPath, 'utf8'));
+}
+
+try {
+  writeMockBinary();
+  process.env.GLIMPSE_BINARY_PATH = mockBinary;
+  process.env.GLIMPSE_OPEN_LINKS_ARGS = argsPath;
+
+  let args = await openMockWindow({ openLinks: true });
+  if (!args.includes('--open-links')) fail('expected --open-links flag');
+  if (args.includes('--open-links-app')) fail('did not expect --open-links-app when only openLinks=true');
+  pass('mapped openLinks -> --open-links');
+
+  args = await openMockWindow({ openLinksApp: APP_PATH });
+  if (!args.includes('--open-links-app')) fail('expected --open-links-app flag');
+  if (!args.includes(APP_PATH)) fail(`expected custom app path argument (${APP_PATH})`);
+  if (args.includes('--open-links')) fail('did not expect explicit --open-links when only openLinksApp is set');
+  pass('mapped openLinksApp -> --open-links-app');
+
+  pass('open-links args mapping verified');
+  console.log('\nopen-links test passed');
+} finally {
+  rmSync(tmpDir, { recursive: true, force: true });
+}

--- a/test/test.mjs
+++ b/test/test.mjs
@@ -41,7 +41,12 @@ console.log('glimpse integration test\n');
 let win;
 try {
   // Step 1: Open window
-  win = open(HTML, { title: 'Glimpse Test', width: 400, height: 300 });
+  win = open(HTML, {
+    title: 'Glimpse Test',
+    width: 400,
+    height: 300,
+    openLinks: true,
+  });
   pass('Window opened');
 
   // Step 2: Wait for ready (open() internally sets HTML on ready, then emits ready to us)


### PR DESCRIPTION

  ## Summary
  Add support for opening clicked web links in external browsers from Glimpse windows.

  ## Changes
  - Added native Swift flags and config handling:
    - `--open-links`
    - `--open-links-app <path>`
    - `openLinks` / `openLinksApp` behavior for `http`/`https` links
  - Intercepted `WKWebView` link navigation to route link clicks to external browser
  handling.
  - Updated Node wrapper and CLI parsing:
    - `src/glimpse.mjs` options: `openLinks`, `openLinksApp`
    - `bin/glimpse.mjs` flags: `--open-links`, `--open-links-app`
  - Added regression coverage:
    - `test/open-links.test.mjs` validates argument mapping
  - Updated integration test to include the new option usage.
  - Docs and metadata updates:
    - `README.md`, `skills/glimpse/SKILL.md`, `package.json`
    - Added changelog note in `CHANGELOG.md`

  ## Verification
  - `npm run build`
  - `npm test`