### PR TITLE
Linux: Chromium CDP backend (zero-compile alternative to WebKitGTK)

### DIFF
--- a/src/chromium-backend.mjs
+++ b/src/chromium-backend.mjs
@@ -1,0 +1,1095 @@
+#!/usr/bin/env node
+
+/**
+ * Glimpse Chromium Backend
+ *
+ * Drop-in replacement for the native binary on Linux. Speaks the same
+ * Glimpse JSON Lines protocol on stdin/stdout, but uses system Chromium
+ * via CDP (Chrome DevTools Protocol) over pipe instead of WebKitGTK.
+ *
+ * Usage: node chromium-backend.mjs [--width 800] [--height 600] [--frameless] ...
+ */
+
+import { spawn, execSync, execFileSync } from 'node:child_process';
+import { createInterface } from 'node:readline';
+import { existsSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { createConnection } from 'node:net';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+// ── Helpers ─────────────────────────────────────────────────────────────────
+
+function log(msg) {
+  process.stderr.write(`[glimpse] ${msg}\n`);
+}
+
+function emitEvent(obj) {
+  process.stdout.write(JSON.stringify(obj) + '\n');
+}
+
+// ── CLI Parsing ─────────────────────────────────────────────────────────────
+
+function parseArgs() {
+  const config = {
+    width: 800,
+    height: 600,
+    title: 'Glimpse',
+    frameless: false,
+    floating: false,
+    transparent: false,
+    clickThrough: false,
+    followCursor: false,
+    followMode: 'snap',
+    cursorAnchor: null,
+    cursorOffsetX: null,
+    cursorOffsetY: null,
+    x: null,
+    y: null,
+    hidden: false,
+    autoClose: false,
+    openLinks: false,
+    openLinksApp: null,
+    statusItem: false,
+  };
+
+  const args = process.argv.slice(2);
+  for (let i = 0; i < args.length; i++) {
+    switch (args[i]) {
+      case '--width':       config.width = parseInt(args[++i]) || 800; break;
+      case '--height':      config.height = parseInt(args[++i]) || 600; break;
+      case '--title':       config.title = args[++i] || 'Glimpse'; break;
+      case '--x':           config.x = parseInt(args[++i]); break;
+      case '--y':           config.y = parseInt(args[++i]); break;
+      case '--frameless':   config.frameless = true; break;
+      case '--floating':    config.floating = true; break;
+      case '--transparent': config.transparent = true; break;
+      case '--click-through': config.clickThrough = true; break;
+      case '--follow-cursor': config.followCursor = true; break;
+      case '--follow-mode': config.followMode = args[++i] || 'snap'; break;
+      case '--cursor-anchor': config.cursorAnchor = args[++i] || null; break;
+      case '--cursor-offset-x': config.cursorOffsetX = parseInt(args[++i]); break;
+      case '--cursor-offset-y': config.cursorOffsetY = parseInt(args[++i]); break;
+      case '--hidden':      config.hidden = true; break;
+      case '--auto-close':  config.autoClose = true; break;
+      case '--open-links':  config.openLinks = true; break;
+      case '--open-links-app': config.openLinks = true; config.openLinksApp = args[++i]; break;
+      case '--status-item': config.statusItem = true; break;
+    }
+  }
+
+  // Default offsets: 20/-20 for offset-only, 0/0 when anchor is set
+  if (config.cursorOffsetX == null) config.cursorOffsetX = config.cursorAnchor ? 0 : 20;
+  if (config.cursorOffsetY == null) config.cursorOffsetY = config.cursorAnchor ? 0 : -20;
+
+  return config;
+}
+
+// ── Chrome Discovery ────────────────────────────────────────────────────────
+
+function findChrome() {
+  if (process.env.GLIMPSE_CHROME_PATH) return process.env.GLIMPSE_CHROME_PATH;
+
+  const candidates = [
+    'chromium',
+    'chromium-browser',
+    'google-chrome-stable',
+    'google-chrome',
+    'chrome',
+  ];
+
+  for (const name of candidates) {
+    try {
+      const path = execSync(`which ${name}`, { encoding: 'utf8', timeout: 2000 }).trim();
+      if (path) return path;
+    } catch {}
+  }
+
+  return null;
+}
+
+// ── Cursor Anchor Math ──────────────────────────────────────────────────────
+// Matches the Swift and Rust backends exactly.
+
+const SAFE_LEFT = 20, SAFE_RIGHT = 27, SAFE_UP = 15, SAFE_DOWN = 39;
+
+function computeTarget(cx, cy, winW, winH, anchor, offsetX, offsetY) {
+  switch (anchor) {
+    case 'top-left':     return { x: cx - SAFE_LEFT - winW + offsetX, y: cy - SAFE_UP - winH + offsetY };
+    case 'top-right':    return { x: cx + SAFE_RIGHT + offsetX,       y: cy - SAFE_UP - winH + offsetY };
+    case 'right':        return { x: cx + SAFE_RIGHT + offsetX,       y: cy - winH / 2 + offsetY };
+    case 'bottom-right': return { x: cx + SAFE_RIGHT + offsetX,       y: cy + SAFE_DOWN + offsetY };
+    case 'bottom-left':  return { x: cx - SAFE_LEFT - winW + offsetX, y: cy + SAFE_DOWN + offsetY };
+    case 'left':         return { x: cx - SAFE_LEFT - winW + offsetX, y: cy - winH / 2 + offsetY };
+    default:             return { x: cx + offsetX, y: cy + offsetY };
+  }
+}
+
+function computeCursorTip(winW, winH, anchor, offsetX, offsetY) {
+  if (anchor) {
+    const base = computeTarget(0, 0, winW, winH, anchor, offsetX, offsetY);
+    return { x: Math.round(-base.x), y: Math.round(winH - (-base.y)) };
+  }
+  return { x: Math.round(-offsetX), y: Math.round(winH + offsetY) };
+}
+
+// ── Spring Physics ──────────────────────────────────────────────────────────
+
+const SPRING_STIFFNESS = 400, SPRING_DAMPING = 28, SPRING_DT = 1 / 120, SPRING_SETTLE = 0.5;
+
+class SpringState {
+  constructor(x, y) {
+    this.posX = x; this.posY = y;
+    this.velX = 0; this.velY = 0;
+    this.targetX = x; this.targetY = y;
+  }
+
+  tick() {
+    const dx = this.targetX - this.posX;
+    const dy = this.targetY - this.posY;
+    this.velX += (SPRING_STIFFNESS * dx - SPRING_DAMPING * this.velX) * SPRING_DT;
+    this.velY += (SPRING_STIFFNESS * dy - SPRING_DAMPING * this.velY) * SPRING_DT;
+    this.posX += this.velX * SPRING_DT;
+    this.posY += this.velY * SPRING_DT;
+
+    const dist = Math.sqrt(dx * dx + dy * dy);
+    const vel = Math.sqrt(this.velX * this.velX + this.velY * this.velY);
+    if (dist < SPRING_SETTLE && vel < SPRING_SETTLE) {
+      this.posX = this.targetX;
+      this.posY = this.targetY;
+      this.velX = 0;
+      this.velY = 0;
+      return true;
+    }
+    return false;
+  }
+}
+
+// ── X11 Helpers ─────────────────────────────────────────────────────────────
+
+function xdotoolSearch(pid) {
+  try {
+    const out = execFileSync('xdotool', ['search', '--pid', String(pid), '--class', 'chromium'], {
+      encoding: 'utf8', timeout: 5000,
+    });
+    return out.trim().split('\n').filter(Boolean);
+  } catch { return []; }
+}
+
+function findChromeWindow(pid, expectedW, expectedH) {
+  const wids = xdotoolSearch(pid);
+  for (const wid of wids) {
+    try {
+      const geom = execFileSync('xdotool', ['getwindowgeometry', '--shell', wid], {
+        encoding: 'utf8', timeout: 1000,
+      });
+      const w = parseInt((geom.match(/WIDTH=(\d+)/) || [])[1]);
+      const h = parseInt((geom.match(/HEIGHT=(\d+)/) || [])[1]);
+      if (Math.abs(w - expectedW) < 50 && Math.abs(h - expectedH) < 50) return wid;
+    } catch {}
+  }
+  // Fallback: return the last wid (often the main window)
+  return wids.length > 0 ? wids[wids.length - 1] : null;
+}
+
+function xSetAbove(wid) {
+  try {
+    execFileSync('xprop', [
+      '-id', wid,
+      '-f', '_NET_WM_STATE', '32a',
+      '-set', '_NET_WM_STATE', '_NET_WM_STATE_ABOVE,_NET_WM_STATE_SKIP_TASKBAR,_NET_WM_STATE_SKIP_PAGER',
+    ], { timeout: 2000 });
+  } catch (e) { log(`xSetAbove failed: ${e.message}`); }
+}
+
+function xSetFrameless(wid) {
+  try {
+    execFileSync('xprop', [
+      '-id', wid,
+      '-f', '_MOTIF_WM_HINTS', '32c',
+      '-set', '_MOTIF_WM_HINTS', '2, 0, 0, 0, 0',
+    ], { timeout: 2000 });
+  } catch (e) { log(`xSetFrameless failed: ${e.message}`); }
+}
+
+function xSetClickThrough(wid) {
+  // Use python3 + ctypes to set empty X11 input shape via XFixes.
+  // This avoids needing a compiled C helper.
+  const script = `
+import ctypes, ctypes.util, sys
+wid = int(sys.argv[1])
+x11 = ctypes.cdll.LoadLibrary(ctypes.util.find_library('X11'))
+xfixes = ctypes.cdll.LoadLibrary(ctypes.util.find_library('Xfixes'))
+dpy = x11.XOpenDisplay(None)
+if not dpy: sys.exit(1)
+xfixes.XFixesCreateRegion.restype = ctypes.c_ulong
+region = xfixes.XFixesCreateRegion(dpy, None, 0)
+xfixes.XFixesSetWindowShapeRegion(dpy, int(wid), 2, 0, 0, region)
+xfixes.XFixesDestroyRegion(dpy, region)
+x11.XFlush(dpy)
+x11.XCloseDisplay(dpy)
+`;
+  try {
+    execFileSync('python3', ['-c', script, wid], { timeout: 3000 });
+  } catch (e) { log(`xSetClickThrough failed: ${e.message}`); }
+}
+
+function xWindowMove(wid, x, y) {
+  try {
+    execFileSync('xdotool', ['windowmove', '--sync', wid, String(Math.round(x)), String(Math.round(y))], {
+      timeout: 1000,
+    });
+  } catch {}
+}
+
+function xWindowActivate(wid) {
+  try {
+    execFileSync('xdotool', ['windowactivate', '--sync', wid], { timeout: 2000 });
+  } catch {}
+}
+
+function xWindowMinimize(wid) {
+  try {
+    execFileSync('xdotool', ['windowminimize', '--sync', wid], { timeout: 2000 });
+  } catch {}
+}
+
+function xGetCursorPosition() {
+  try {
+    const out = execFileSync('xdotool', ['getmouselocation', '--shell'], {
+      encoding: 'utf8', timeout: 500,
+    });
+    const x = parseInt((out.match(/X=(\d+)/) || [])[1]);
+    const y = parseInt((out.match(/Y=(\d+)/) || [])[1]);
+    if (!isNaN(x) && !isNaN(y)) return { x, y };
+  } catch {}
+  return null;
+}
+
+// ── Hyprland IPC ────────────────────────────────────────────────────────────
+
+function hyprlandSocketPath() {
+  const sig = process.env.HYPRLAND_INSTANCE_SIGNATURE;
+  if (!sig) return null;
+
+  const candidates = [];
+  if (process.env.XDG_RUNTIME_DIR) {
+    candidates.push(join(process.env.XDG_RUNTIME_DIR, 'hypr', sig, '.socket.sock'));
+  }
+  const uid = process.env.UID || String(process.getuid?.() ?? '');
+  if (uid) {
+    candidates.push(join('/run/user', uid, 'hypr', sig, '.socket.sock'));
+  }
+  candidates.push(join('/tmp', 'hypr', sig, '.socket.sock'));
+
+  return candidates.find(p => existsSync(p)) || null;
+}
+
+function hyprlandGetCursorPos(socketPath) {
+  return new Promise((resolve) => {
+    const sock = createConnection(socketPath, () => {
+      sock.write('cursorpos');
+    });
+    let data = '';
+    sock.on('data', (chunk) => { data += chunk.toString(); });
+    sock.on('end', () => {
+      const parts = data.trim().split(/[,\s]+/);
+      if (parts.length >= 2) {
+        const x = Math.round(parseFloat(parts[0]));
+        const y = Math.round(parseFloat(parts[1]));
+        if (!isNaN(x) && !isNaN(y)) { resolve({ x, y }); return; }
+      }
+      resolve(null);
+    });
+    sock.on('error', () => resolve(null));
+    sock.setTimeout(200, () => { sock.destroy(); resolve(null); });
+  });
+}
+
+// Synchronous version for startup (before event loop is running)
+function hyprlandGetCursorPosSync(socketPath) {
+  try {
+    const out = execFileSync('socat', ['-', `UNIX-CONNECT:${socketPath}`], {
+      input: 'cursorpos', encoding: 'utf8', timeout: 500,
+    });
+    const parts = out.trim().split(/[,\s]+/);
+    if (parts.length >= 2) {
+      const x = Math.round(parseFloat(parts[0]));
+      const y = Math.round(parseFloat(parts[1]));
+      if (!isNaN(x) && !isNaN(y)) return { x, y };
+    }
+  } catch {}
+  // Fallback: try a quick Node net connect trick via execFileSync
+  try {
+    const script = `
+      const s=require('net').createConnection('${socketPath}',()=>s.write('cursorpos'));
+      s.on('data',d=>{process.stdout.write(d);s.destroy()});
+      s.on('error',()=>process.exit(1));
+    `;
+    const out = execFileSync(process.execPath, ['-e', script], {
+      encoding: 'utf8', timeout: 500,
+    });
+    const parts = out.trim().split(/[,\s]+/);
+    if (parts.length >= 2) {
+      const x = Math.round(parseFloat(parts[0]));
+      const y = Math.round(parseFloat(parts[1]));
+      if (!isNaN(x) && !isNaN(y)) return { x, y };
+    }
+  } catch {}
+  return null;
+}
+
+// ── CDP Transport ───────────────────────────────────────────────────────────
+
+class CDPConnection {
+  #proc;
+  #nextId = 1;
+  #pending = new Map();
+  #eventHandlers = new Map();
+  #buf = '';
+  #ready;
+  #readyResolve;
+
+  constructor(chromePath, chromeArgs) {
+    this.#ready = new Promise(r => { this.#readyResolve = r; });
+
+    this.#proc = spawn(chromePath, chromeArgs, {
+      stdio: ['pipe', 'pipe', 'pipe', 'pipe', 'pipe'],
+    });
+
+    this.#proc.stderr.on('data', (d) => {
+      const s = d.toString();
+      // Only log interesting errors, suppress noisy ones
+      if (s.includes('ERROR') && !s.includes('leveldb') && !s.includes('sandbox') &&
+          !s.includes('gbm_support') && !s.includes('command_buffer') &&
+          !s.includes('context_provider') && !s.includes('shared_memory') &&
+          !s.includes('gcm') && !s.includes('GCM') && !s.includes('registration') &&
+          !s.includes('wrong_secret') && !s.includes('DEPRECATED_ENDPOINT')) {
+        log(`chrome: ${s.trim()}`);
+      }
+    });
+
+    this.#proc.stdout.on('data', () => {}); // drain stdout
+
+    // CDP responses come on FD 4 (chrome writes here)
+    this.#proc.stdio[4].on('data', (chunk) => {
+      this.#buf += chunk.toString();
+      const parts = this.#buf.split('\0');
+      this.#buf = parts.pop();
+      for (const part of parts) {
+        if (!part.trim()) continue;
+        let msg;
+        try { msg = JSON.parse(part); } catch { continue; }
+        if (msg.id && this.#pending.has(msg.id)) {
+          this.#pending.get(msg.id)(msg);
+          this.#pending.delete(msg.id);
+        } else if (msg.method) {
+          const handlers = this.#eventHandlers.get(msg.method);
+          if (handlers) {
+            handlers.forEach(fn => fn(msg.params, msg.sessionId));
+          }
+        }
+      }
+    });
+
+    this.#proc.on('exit', (code) => {
+      // Resolve any pending promises so nothing hangs
+      for (const [, resolve] of this.#pending) resolve({ error: { message: 'Process exited' } });
+      this.#pending.clear();
+    });
+
+    // Signal ready immediately -- caller will poll for targets
+    setTimeout(() => this.#readyResolve(), 0);
+  }
+
+  get proc() { return this.#proc; }
+  get pid() { return this.#proc.pid; }
+
+  send(method, params = {}, sessionId) {
+    return new Promise((resolve) => {
+      const id = this.#nextId++;
+      this.#pending.set(id, resolve);
+      const msg = sessionId
+        ? { id, method, params, sessionId }
+        : { id, method, params };
+      try {
+        this.#proc.stdio[3].write(JSON.stringify(msg) + '\0');
+      } catch {
+        this.#pending.delete(id);
+        resolve({ error: { message: 'Write failed' } });
+      }
+    });
+  }
+
+  on(eventName, handler) {
+    if (!this.#eventHandlers.has(eventName)) this.#eventHandlers.set(eventName, []);
+    this.#eventHandlers.get(eventName).push(handler);
+  }
+
+  kill() {
+    try { this.#proc.kill(); } catch {}
+  }
+}
+
+// ── Status Item (Tray) Helper ───────────────────────────────────────────────
+
+const TRAY_HELPER_SCRIPT = `
+import gi, sys, json, os
+gi.require_version('Gtk', '3.0')
+from gi.repository import Gtk, GLib, GdkPixbuf
+
+import warnings
+warnings.filterwarnings("ignore", category=DeprecationWarning)
+
+class Tray:
+    def __init__(self, title):
+        self.icon = Gtk.StatusIcon()
+        self.icon.set_from_icon_name("dialog-information")
+        self.icon.set_title(title)
+        self.icon.set_tooltip_text(title)
+        self.icon.set_visible(True)
+        self.icon.connect("activate", self.on_click)
+        channel = GLib.IOChannel.unix_new(sys.stdin.fileno())
+        GLib.io_add_watch(channel, GLib.IO_IN | GLib.IO_HUP, self.on_stdin)
+        print(json.dumps({"type": "tray-ready"}), flush=True)
+
+    def on_click(self, icon):
+        print(json.dumps({"type": "click"}), flush=True)
+
+    def on_stdin(self, channel, condition):
+        if condition & GLib.IO_HUP:
+            Gtk.main_quit()
+            return False
+        line = channel.readline()
+        if not line:
+            Gtk.main_quit()
+            return False
+        try:
+            msg = json.loads(line)
+            if msg.get("type") == "title":
+                self.icon.set_title(msg.get("title", ""))
+                self.icon.set_tooltip_text(msg.get("title", ""))
+        except:
+            pass
+        return True
+
+title = sys.argv[1] if len(sys.argv) > 1 else "Glimpse"
+Tray(title)
+Gtk.main()
+`;
+
+function spawnTrayHelper(title) {
+  const proc = spawn('python3', ['-c', TRAY_HELPER_SCRIPT, title], {
+    stdio: ['pipe', 'pipe', 'inherit'],
+  });
+  proc.on('error', () => {});
+  return proc;
+}
+
+// ── Main ────────────────────────────────────────────────────────────────────
+
+async function main() {
+  const config = parseArgs();
+
+  const chromePath = findChrome();
+  if (!chromePath) {
+    log('No Chromium or Chrome installation found.');
+    log('Install chromium, chromium-browser, or google-chrome-stable, or set GLIMPSE_CHROME_PATH.');
+    process.exit(1);
+  }
+
+  // Create temp profile
+  const profileDir = mkdtempSync(join(tmpdir(), 'glimpse-chromium-'));
+  const cleanup = () => { try { rmSync(profileDir, { recursive: true, force: true }); } catch {} };
+  process.on('exit', cleanup);
+  process.on('SIGTERM', () => { closeAndExit(); });
+  process.on('SIGINT', () => { closeAndExit(); });
+
+  // ── State ──────────────────────────────────────────────────────────
+  let sessionId = null;
+  let windowId = null;
+  let xWindowId = null;
+  let closed = false;
+  let readyCount = 0; // Track ready events (first = blank page, second = user content)
+  let followEnabled = config.followCursor;
+  let cursorAnchor = config.cursorAnchor;
+  let followMode = config.followMode;
+  let cursorPollerInterval = null;
+  let springTimer = null;
+  let spring = null;
+  let lastCursor = null;
+  let trayProc = null;
+  let trayVisible = false;
+  let windowModesDone = false;
+
+  const offsetX = config.cursorOffsetX;
+  const offsetY = config.cursorOffsetY;
+
+  // ── Cursor backend detection ───────────────────────────────────────
+  // Prefer Hyprland IPC (async, no subprocess spawn per poll) over xdotool.
+  const hyprSocket = hyprlandSocketPath();
+  const cursorBackend = hyprSocket ? 'hyprland' : 'x11';
+  if (hyprSocket) log(`cursor backend: Hyprland IPC (${hyprSocket})`);
+
+  /** Get cursor position -- async for Hyprland, sync fallback for X11. */
+  async function getCursorPositionAsync() {
+    if (hyprSocket) {
+      const pos = await hyprlandGetCursorPos(hyprSocket);
+      if (pos) return pos;
+    }
+    return xGetCursorPosition();
+  }
+
+  /** Get cursor position synchronously (startup only). */
+  function getCursorPositionSync() {
+    if (hyprSocket) {
+      const pos = hyprlandGetCursorPosSync(hyprSocket);
+      if (pos) return pos;
+    }
+    return xGetCursorPosition();
+  }
+
+  // ── Build Chrome args ──────────────────────────────────────────────
+
+  const chromeArgs = [
+    '--app=data:text/html,<body></body>',
+    '--no-first-run',
+    '--no-default-browser-check',
+    '--disable-background-networking',
+    '--disable-default-apps',
+    '--disable-extensions',
+    '--disable-sync',
+    '--disable-translate',
+    '--disable-features=TranslateUI',
+    '--metrics-recording-only',
+    '--no-pings',
+    `--user-data-dir=${profileDir}`,
+    '--remote-debugging-pipe',
+    `--window-size=${config.width},${config.height}`,
+  ];
+
+  if (config.transparent) chromeArgs.push('--enable-transparent-visuals');
+
+  // Initial position
+  if (config.followCursor) {
+    const cursor = getCursorPositionSync();
+    if (cursor) {
+      const pos = computeTarget(cursor.x, cursor.y, config.width, config.height,
+        cursorAnchor, offsetX, offsetY);
+      chromeArgs.push(`--window-position=${Math.round(pos.x)},${Math.round(pos.y)}`);
+      lastCursor = cursor;
+    }
+  } else if (config.hidden) {
+    chromeArgs.push('--window-position=-10000,-10000');
+  } else if (config.x != null && config.y != null) {
+    chromeArgs.push(`--window-position=${config.x},${config.y}`);
+  }
+
+  // ── Launch Chrome ──────────────────────────────────────────────────
+
+  const cdp = new CDPConnection(chromePath, chromeArgs);
+
+  cdp.proc.on('exit', () => {
+    if (!closed) {
+      closed = true;
+      emitEvent({ type: 'closed' });
+      cleanup();
+      process.exit(0);
+    }
+  });
+
+  // ── CDP Setup ──────────────────────────────────────────────────────
+
+  // Wait for the page target to appear
+  let page = null;
+  for (let attempt = 0; attempt < 100; attempt++) {
+    await new Promise(r => setTimeout(r, 50));
+    const resp = await cdp.send('Target.getTargets');
+    if (resp.result?.targetInfos) {
+      page = resp.result.targetInfos.find(t => t.type === 'page');
+      if (page) break;
+    }
+  }
+
+  if (!page) {
+    log('Failed to find page target');
+    cdp.kill();
+    process.exit(1);
+  }
+
+  // Attach to the page
+  const attachResp = await cdp.send('Target.attachToTarget', {
+    targetId: page.targetId, flatten: true,
+  });
+  sessionId = attachResp.result?.sessionId;
+  if (!sessionId) {
+    log('Failed to attach to page target');
+    cdp.kill();
+    process.exit(1);
+  }
+
+  // ── CDP Event Handlers ─────────────────────────────────────────────
+  // Register handlers BEFORE enabling domains so we don't miss initial events.
+
+  cdp.on('Runtime.bindingCalled', (params) => {
+    if (params.name !== '__glimpse_send') return;
+    let data;
+    try { data = JSON.parse(params.payload); } catch { return; }
+
+    if (data.__glimpse_close) {
+      closeAndExit();
+      return;
+    }
+
+    emitEvent({ type: 'message', data });
+    if (config.autoClose) closeAndExit();
+  });
+
+  cdp.on('Page.loadEventFired', async () => {
+    readyCount++;
+    const info = await collectSystemInfo();
+    emitEvent({ type: 'ready', ...info });
+
+    // Apply window modes once after first load (window exists now)
+    if (!windowModesDone) {
+      windowModesDone = true;
+      await applyWindowModes();
+    }
+  });
+
+  cdp.on('Fetch.requestPaused', (params) => {
+    const url = params.request?.url || '';
+    if ((url.startsWith('http://') || url.startsWith('https://')) && config.openLinks) {
+      cdp.send('Fetch.failRequest', { requestId: params.requestId, errorReason: 'Aborted' }, sessionId);
+      try {
+        if (config.openLinksApp) {
+          execFileSync(config.openLinksApp, [url], { timeout: 5000 });
+        } else {
+          execFileSync('xdg-open', [url], { timeout: 5000 });
+        }
+      } catch (e) { log(`open-links failed: ${e.message}`); }
+    } else {
+      cdp.send('Fetch.continueRequest', { requestId: params.requestId }, sessionId);
+    }
+  });
+
+  // ── Enable Domains & Setup ─────────────────────────────────────────
+
+  // Get window ID for bounds control
+  const winResp = await cdp.send('Browser.getWindowForTarget', { targetId: page.targetId });
+  windowId = winResp.result?.windowId;
+
+  // Set up bridge: Runtime.addBinding creates a global function
+  await cdp.send('Runtime.addBinding', { name: '__glimpse_send' }, sessionId);
+
+  // Compute initial cursorTip value for the bridge
+  let initialCursorTip = 'null';
+  if (followEnabled) {
+    const tip = computeCursorTip(config.width, config.height, cursorAnchor, offsetX, offsetY);
+    initialCursorTip = `{x:${tip.x},y:${tip.y}}`;
+  }
+
+  // Inject bridge script (survives navigations)
+  await cdp.send('Page.addScriptToEvaluateOnNewDocument', {
+    source: `
+      window.glimpse = {
+        cursorTip: ${initialCursorTip},
+        send(data) { __glimpse_send(JSON.stringify(data)); },
+        close() { __glimpse_send(JSON.stringify({ __glimpse_close: true })); }
+      };
+    `,
+  }, sessionId);
+
+  // Transparent background
+  if (config.transparent) {
+    await cdp.send('Emulation.setDefaultBackgroundColorOverride', {
+      color: { r: 0, g: 0, b: 0, a: 0 },
+    }, sessionId);
+  }
+
+  // Open links interception
+  if (config.openLinks) {
+    await cdp.send('Fetch.enable', {
+      patterns: [{ urlPattern: 'http://*', requestStage: 'Request' }, { urlPattern: 'https://*', requestStage: 'Request' }],
+    }, sessionId);
+  }
+
+  // NOW enable Page and Runtime domains -- events will flow to our handlers above
+  await cdp.send('Page.enable', {}, sessionId);
+  await cdp.send('Runtime.enable', {}, sessionId);
+
+  // The initial blank page has already loaded, so Page.loadEventFired won't fire again.
+  // Emit a synthetic ready for the initial blank page, just like native backends do.
+  {
+    const info = await collectSystemInfo();
+    emitEvent({ type: 'ready', ...info });
+    windowModesDone = true;
+    await applyWindowModes();
+  }
+
+  // ── Status Item Mode ───────────────────────────────────────────────
+
+  if (config.statusItem) {
+    trayProc = spawnTrayHelper(config.title === 'Glimpse' ? 'G' : config.title);
+    const trayRl = createInterface({ input: trayProc.stdout });
+    trayRl.on('line', (line) => {
+      try {
+        const msg = JSON.parse(line);
+        if (msg.type === 'click') {
+          emitEvent({ type: 'click' });
+          // Toggle window visibility
+          trayVisible = !trayVisible;
+          if (trayVisible) {
+            showWindow();
+          } else {
+            hideWindow();
+          }
+        }
+      } catch {}
+    });
+    trayProc.on('exit', () => { trayProc = null; });
+    // Start hidden in status-item mode
+    config.hidden = true;
+  }
+
+  // ── Window Mode Application ────────────────────────────────────────
+
+  async function applyWindowModes() {
+    // Wait a bit for the window to be mapped
+    await new Promise(r => setTimeout(r, 200));
+
+    xWindowId = findChromeWindow(cdp.pid, config.width, config.height);
+    if (!xWindowId) {
+      log('Could not find Chrome X11 window for mode application');
+      return;
+    }
+
+    if (config.frameless) xSetFrameless(xWindowId);
+    if (config.floating || config.followCursor) xSetAbove(xWindowId);
+    if (config.clickThrough) xSetClickThrough(xWindowId);
+
+    if (config.hidden) {
+      xWindowMove(xWindowId, -10000, -10000);
+    }
+
+    // Start follow-cursor tracking
+    if (config.followCursor) {
+      startFollowCursor();
+    }
+
+    // Inject cursorTip if follow-cursor is active
+    if (followEnabled) {
+      const tip = computeCursorTip(config.width, config.height, cursorAnchor, offsetX, offsetY);
+      cdp.send('Runtime.evaluate', {
+        expression: `window.glimpse && (window.glimpse.cursorTip = {x:${tip.x},y:${tip.y}})`,
+      }, sessionId);
+    }
+  }
+
+  // ── System Info ────────────────────────────────────────────────────
+
+  async function collectSystemInfo() {
+    const infoJS = `JSON.stringify({
+      sw: screen.width, sh: screen.height,
+      avW: screen.availWidth, avH: screen.availHeight,
+      avL: typeof screen.availLeft !== 'undefined' ? screen.availLeft : 0,
+      avT: typeof screen.availTop !== 'undefined' ? screen.availTop : 0,
+      dpr: devicePixelRatio,
+      dark: matchMedia('(prefers-color-scheme:dark)').matches,
+      reduceMotion: matchMedia('(prefers-reduced-motion:reduce)').matches,
+      contrast: matchMedia('(prefers-contrast:more)').matches,
+    })`;
+
+    let screenData = {};
+    try {
+      const r = await cdp.send('Runtime.evaluate', { expression: infoJS }, sessionId);
+      if (r.result?.result?.value) screenData = JSON.parse(r.result.result.value);
+    } catch {}
+
+    const screen = {
+      width: screenData.sw || 0,
+      height: screenData.sh || 0,
+      scaleFactor: Math.round(screenData.dpr || 1),
+      visibleX: screenData.avL || 0,
+      visibleY: screenData.avT || 0,
+      visibleWidth: screenData.avW || 0,
+      visibleHeight: screenData.avH || 0,
+    };
+
+    const cursor = lastCursor || getCursorPositionSync() || { x: 0, y: 0 };
+
+    let cursorTip = null;
+    if (followEnabled) {
+      cursorTip = computeCursorTip(config.width, config.height, cursorAnchor, offsetX, offsetY);
+    }
+
+    return {
+      screen,
+      screens: [{ x: 0, y: 0, ...screen }],
+      appearance: {
+        darkMode: screenData.dark || false,
+        accentColor: null,
+        reduceMotion: screenData.reduceMotion || false,
+        increaseContrast: screenData.contrast || false,
+      },
+      cursor,
+      cursorTip,
+    };
+  }
+
+  // ── Follow Cursor ──────────────────────────────────────────────────
+
+  function startFollowCursor() {
+    if (cursorPollerInterval) return;
+
+    if (followMode === 'spring') {
+      const cursor = getCursorPositionSync();
+      if (cursor) {
+        const pos = computeTarget(cursor.x, cursor.y, config.width, config.height,
+          cursorAnchor, offsetX, offsetY);
+        spring = new SpringState(pos.x, pos.y);
+      } else {
+        spring = new SpringState(0, 0);
+      }
+    }
+
+    if (cursorBackend === 'hyprland') {
+      // Async Hyprland IPC polling -- no subprocess spawn per tick
+      let polling = false;
+      cursorPollerInterval = setInterval(async () => {
+        if (!followEnabled || !xWindowId || polling) return;
+        polling = true;
+        const cursor = await hyprlandGetCursorPos(hyprSocket);
+        polling = false;
+        if (!cursor) return;
+        lastCursor = cursor;
+
+        const target = computeTarget(cursor.x, cursor.y, config.width, config.height,
+          cursorAnchor, offsetX, offsetY);
+
+        if (followMode === 'spring' && spring) {
+          spring.targetX = target.x;
+          spring.targetY = target.y;
+        } else {
+          xWindowMove(xWindowId, target.x, target.y);
+        }
+      }, 8);
+    } else {
+      // X11: synchronous xdotool polling
+      cursorPollerInterval = setInterval(() => {
+        if (!followEnabled || !xWindowId) return;
+        const cursor = xGetCursorPosition();
+        if (!cursor) return;
+        lastCursor = cursor;
+
+        const target = computeTarget(cursor.x, cursor.y, config.width, config.height,
+          cursorAnchor, offsetX, offsetY);
+
+        if (followMode === 'spring' && spring) {
+          spring.targetX = target.x;
+          spring.targetY = target.y;
+        } else {
+          xWindowMove(xWindowId, target.x, target.y);
+        }
+      }, 8);
+    }
+
+    // Spring physics timer
+    if (followMode === 'spring') {
+      springTimer = setInterval(() => {
+        if (!spring || !xWindowId) return;
+        const settled = spring.tick();
+        xWindowMove(xWindowId, spring.posX, spring.posY);
+      }, 8);
+    }
+  }
+
+  function stopFollowCursor() {
+    if (cursorPollerInterval) { clearInterval(cursorPollerInterval); cursorPollerInterval = null; }
+    if (springTimer) { clearInterval(springTimer); springTimer = null; }
+    spring = null;
+  }
+
+  // ── Window Show/Hide ───────────────────────────────────────────────
+
+  function showWindow(title) {
+    if (title != null) {
+      cdp.send('Runtime.evaluate', {
+        expression: `document.title = ${JSON.stringify(title)}`,
+      }, sessionId);
+    }
+    if (xWindowId) {
+      if (config.hidden || config.statusItem) {
+        // Move back from off-screen
+        const cursor = getCursorPositionSync();
+        let x = config.x != null ? config.x : 100;
+        let y = config.y != null ? config.y : 100;
+        if (cursor && config.statusItem) {
+          // Position near cursor for tray popover behavior
+          x = cursor.x - config.width / 2;
+          y = cursor.y - config.height - 30;
+        }
+        xWindowMove(xWindowId, x, y);
+      }
+      xWindowActivate(xWindowId);
+    }
+    config.hidden = false;
+  }
+
+  function hideWindow() {
+    if (xWindowId) xWindowMove(xWindowId, -10000, -10000);
+  }
+
+  // ── Close ──────────────────────────────────────────────────────────
+
+  function closeAndExit() {
+    if (closed) return;
+    closed = true;
+    stopFollowCursor();
+    if (trayProc) { try { trayProc.kill(); } catch {} }
+    cdp.kill();
+    cleanup();
+    // Write 'closed' and wait for stdout to drain before exiting.
+    // This ensures the parent process reads the event before we die.
+    const msg = JSON.stringify({ type: 'closed' }) + '\n';
+    const flushed = process.stdout.write(msg);
+    if (flushed) {
+      setImmediate(() => process.exit(0));
+    } else {
+      process.stdout.once('drain', () => process.exit(0));
+    }
+  }
+
+  // ── Stdin Command Handler ──────────────────────────────────────────
+
+  const rl = createInterface({ input: process.stdin });
+
+  rl.on('line', async (line) => {
+    if (closed) return;
+    const trimmed = line.trim();
+    if (!trimmed) return;
+
+    let msg;
+    try { msg = JSON.parse(trimmed); } catch {
+      log(`bad message: ${trimmed}`);
+      return;
+    }
+
+    switch (msg.type) {
+      case 'html': {
+        // msg.html is base64 encoded
+        const dataUrl = `data:text/html;base64,${msg.html}`;
+        await cdp.send('Page.navigate', { url: dataUrl }, sessionId);
+        break;
+      }
+
+      case 'eval': {
+        if (msg.js) {
+          await cdp.send('Runtime.evaluate', { expression: msg.js }, sessionId);
+        }
+        break;
+      }
+
+      case 'file': {
+        if (msg.path) {
+          await cdp.send('Page.navigate', { url: `file://${msg.path}` }, sessionId);
+        }
+        break;
+      }
+
+      case 'show': {
+        showWindow(msg.title);
+        break;
+      }
+
+      case 'close': {
+        closeAndExit();
+        break;
+      }
+
+      case 'get-info': {
+        const info = await collectSystemInfo();
+        emitEvent({ type: 'info', ...info });
+        break;
+      }
+
+      case 'title': {
+        if (config.statusItem && trayProc) {
+          trayProc.stdin.write(JSON.stringify({ type: 'title', title: msg.title }) + '\n');
+        } else {
+          await cdp.send('Runtime.evaluate', {
+            expression: `document.title = ${JSON.stringify(msg.title || '')}`,
+          }, sessionId);
+        }
+        break;
+      }
+
+      case 'resize': {
+        const w = msg.width || config.width;
+        const h = msg.height || config.height;
+        if (windowId != null) {
+          await cdp.send('Browser.setWindowBounds', {
+            windowId, bounds: { width: w, height: h },
+          });
+        }
+        config.width = w;
+        config.height = h;
+        break;
+      }
+
+      case 'follow-cursor': {
+        const enabled = msg.enabled !== false;
+        if (msg.anchor !== undefined) cursorAnchor = msg.anchor || null;
+        if (msg.mode) {
+          const wasSpring = followMode === 'spring';
+          followMode = msg.mode;
+          if (msg.mode === 'spring' && !wasSpring && xWindowId) {
+            // Initialize spring from current position
+            const cursor = getCursorPositionSync();
+            if (cursor) {
+              const pos = computeTarget(cursor.x, cursor.y, config.width, config.height,
+                cursorAnchor, offsetX, offsetY);
+              spring = new SpringState(pos.x, pos.y);
+            }
+          }
+        }
+
+        if (enabled && !followEnabled) {
+          followEnabled = true;
+          if (xWindowId) {
+            xSetAbove(xWindowId);
+            startFollowCursor();
+          }
+        } else if (!enabled && followEnabled) {
+          followEnabled = false;
+          stopFollowCursor();
+        }
+
+        // Update cursorTip
+        if (followEnabled) {
+          const tip = computeCursorTip(config.width, config.height, cursorAnchor, offsetX, offsetY);
+          await cdp.send('Runtime.evaluate', {
+            expression: `window.glimpse && (window.glimpse.cursorTip = {x:${tip.x},y:${tip.y}})`,
+          }, sessionId);
+        } else {
+          await cdp.send('Runtime.evaluate', {
+            expression: `window.glimpse && (window.glimpse.cursorTip = null)`,
+          }, sessionId);
+        }
+        break;
+      }
+
+      default:
+        log(`Unknown command: ${msg.type}`);
+    }
+  });
+
+  rl.on('close', () => {
+    // stdin EOF -- close
+    closeAndExit();
+  });
+}
+
+main().catch((err) => {
+  log(`Fatal: ${err.message}`);
+  process.exit(1);
+});

--- a/src/follow-cursor-support.mjs
+++ b/src/follow-cursor-support.mjs
@@ -1,7 +1,14 @@
 import { existsSync } from 'node:fs';
-import { join } from 'node:path';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
 
 let cached = null;
+
+function nativeBinaryExists() {
+  return existsSync(join(__dirname, 'glimpse'));
+}
 
 function env(name) {
   return (process.env[name] || '').toLowerCase();
@@ -48,11 +55,18 @@ function detect() {
       : { supported: false, reason: 'Hyprland detected but its IPC socket was not found' };
   }
 
-  if (isWayland) {
+  // Chromium backend supports X11 follow-cursor via xdotool
+  const usingChromium = process.env.GLIMPSE_BACKEND === 'chromium' ||
+    (process.platform === 'linux' && !nativeBinaryExists());
+
+  if (isWayland && !usingChromium) {
     return { supported: false, reason: 'Wayland follow-cursor is disabled without a compositor-specific backend' };
   }
 
   if (isX11) {
+    if (usingChromium) {
+      return { supported: true, reason: null };
+    }
     return { supported: false, reason: 'X11 follow-cursor backend is not implemented yet' };
   }
 

--- a/src/glimpse.mjs
+++ b/src/glimpse.mjs
@@ -8,6 +8,15 @@ import { getFollowCursorSupport, supportsFollowCursor } from './follow-cursor-su
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 
+function resolveChromiumBackend() {
+  return {
+    path: process.execPath,
+    extraArgs: [join(__dirname, 'chromium-backend.mjs')],
+    platform: 'linux-chromium',
+    buildHint: 'Using system Chromium via CDP (no native binary needed)',
+  };
+}
+
 function resolveNativeHost() {
   const override = process.env.GLIMPSE_BINARY_PATH || process.env.GLIMPSE_HOST_PATH;
   if (override) {
@@ -25,12 +34,22 @@ function resolveNativeHost() {
         platform: 'darwin',
         buildHint: "Run 'npm run build:macos' or 'swiftc -O src/glimpse.swift -o src/glimpse'",
       };
-    case 'linux':
-      return {
-        path: join(__dirname, 'glimpse'),
-        platform: 'linux',
-        buildHint: "Run 'npm run build:linux' (requires Rust toolchain and GTK4/WebKitGTK dev packages)",
-      };
+    case 'linux': {
+      const backend = process.env.GLIMPSE_BACKEND;
+      if (backend === 'chromium') return resolveChromiumBackend();
+
+      const nativePath = join(__dirname, 'glimpse');
+      if (backend === 'native' || existsSync(nativePath)) {
+        return {
+          path: nativePath,
+          platform: 'linux',
+          buildHint: "Run 'npm run build:linux' (requires Rust toolchain and GTK4/WebKitGTK dev packages)",
+        };
+      }
+
+      // Auto-fallback: no native binary found, try Chromium backend
+      return resolveChromiumBackend();
+    }
     case 'win32':
       return {
         path: normalize(join(__dirname, '..', 'native', 'windows', 'bin', 'glimpse.exe')),
@@ -170,6 +189,10 @@ class GlimpseWindow extends EventEmitter {
 
 function ensureBinary() {
   const host = resolveNativeHost();
+
+  // Chromium backend doesn't need a compiled binary -- just node + system Chrome
+  if (host.platform === 'linux-chromium') return host;
+
   if (!existsSync(host.path)) {
     const skippedBuildPath = join(__dirname, '..', '.glimpse-build-skipped');
     const skippedReason = existsSync(skippedBuildPath)
@@ -219,7 +242,8 @@ export function open(html, options = {}) {
   if (options.cursorAnchor) args.push('--cursor-anchor', options.cursorAnchor);
   if (options.followMode != null) args.push('--follow-mode', options.followMode);
 
-  const proc = spawn(host.path, args, {
+  const spawnArgs = [...(host.extraArgs || []), ...args];
+  const proc = spawn(host.path, spawnArgs, {
     stdio: ['pipe', 'pipe', 'inherit'],
     windowsHide: process.platform === 'win32',
   });
@@ -239,8 +263,8 @@ class GlimpseStatusItem extends GlimpseWindow {
 export function statusItem(html, options = {}) {
   const host = ensureBinary();
 
-  if (host.platform !== 'darwin') {
-    throw new Error(`statusItem() is only supported on macOS (current platform: ${host.platform})`);
+  if (host.platform !== 'darwin' && host.platform !== 'linux-chromium') {
+    throw new Error(`statusItem() is only supported on macOS and Linux/Chromium (current platform: ${host.platform})`);
   }
 
   const args = ['--status-item'];
@@ -248,7 +272,8 @@ export function statusItem(html, options = {}) {
   if (options.height != null) args.push('--height', String(options.height));
   if (options.title != null)  args.push('--title',  options.title);
 
-  const proc = spawn(host.path, args, { stdio: ['pipe', 'pipe', 'inherit'] });
+  const spawnArgs = [...(host.extraArgs || []), ...args];
+  const proc = spawn(host.path, spawnArgs, { stdio: ['pipe', 'pipe', 'inherit'] });
   return new GlimpseStatusItem(proc, html);
 }
 

--- a/test/test-chromium.mjs
+++ b/test/test-chromium.mjs
@@ -1,0 +1,410 @@
+/**
+ * Comprehensive test for the Chromium backend.
+ * Tests every Glimpse feature: window modes, follow-cursor, eval, messages,
+ * getInfo, setHTML, loadFile, show/hide, prompt, auto-close, status-item.
+ *
+ * Requires: DISPLAY set, system Chromium installed, xdotool available.
+ * Run: DISPLAY=:35 GLIMPSE_BACKEND=chromium node test/test-chromium.mjs
+ */
+
+import { open, prompt, statusItem, supportsFollowCursor } from '../src/glimpse.mjs';
+import { writeFileSync, unlinkSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+const TIMEOUT_MS = 15_000;
+let passed = 0;
+let failed = 0;
+
+function pass(msg) {
+  passed++;
+  console.log(`  \u2713 ${msg}`);
+}
+
+function fail(msg) {
+  failed++;
+  console.error(`  \u2717 ${msg}`);
+}
+
+function waitFor(emitter, event, timeoutMs = TIMEOUT_MS) {
+  return new Promise((resolve, reject) => {
+    const timer = setTimeout(() => reject(new Error(`Timeout: '${event}' after ${timeoutMs}ms`)), timeoutMs);
+    emitter.once(event, (...args) => { clearTimeout(timer); resolve(args); });
+    emitter.once('error', (err) => { clearTimeout(timer); reject(err); });
+  });
+}
+
+async function sleep(ms) {
+  return new Promise(r => setTimeout(r, ms));
+}
+
+console.log('Glimpse Chromium backend - comprehensive test\n');
+
+// ── Test 1: Basic open/ready/message/close ──────────────────────────────
+
+async function testBasic() {
+  console.log('1. Basic: open, ready, eval, message, close');
+  const html = `<html><body>
+    <button id="btn" onclick="window.glimpse.send({action:'clicked'})">Click</button>
+  </body></html>`;
+
+  const win = open(html, { width: 400, height: 300, title: 'Basic Test' });
+  const [info] = await waitFor(win, 'ready');
+
+  if (info?.screen?.width > 0) pass('ready event with screen info');
+  else fail('ready missing screen info');
+
+  if (info?.appearance && typeof info.appearance.darkMode === 'boolean') pass('appearance info present');
+  else fail('appearance info missing');
+
+  if (info?.cursor && typeof info.cursor.x === 'number') pass('cursor info present');
+  else fail('cursor info missing');
+
+  // Eval
+  win.send(`document.getElementById('btn').click()`);
+  const [data] = await waitFor(win, 'message');
+  if (data?.action === 'clicked') pass('message received from eval click');
+  else fail(`expected action=clicked, got ${JSON.stringify(data)}`);
+
+  win.close();
+  await waitFor(win, 'closed');
+  pass('closed event received');
+}
+
+// ── Test 2: setHTML (second navigation) ─────────────────────────────────
+
+async function testSetHTML() {
+  console.log('\n2. setHTML: replace page content');
+  const win = open('<html><body>page1</body></html>', { width: 300, height: 200 });
+  await waitFor(win, 'ready');
+  pass('first ready');
+
+  // Replace with new HTML
+  win.setHTML('<html><body><div id="x" onclick="glimpse.send({page:2})">page2</div></body></html>');
+  await waitFor(win, 'ready');
+  pass('second ready after setHTML');
+
+  win.send(`document.getElementById('x').click()`);
+  const [data] = await waitFor(win, 'message');
+  if (data?.page === 2) pass('message from new page');
+  else fail(`expected page=2, got ${JSON.stringify(data)}`);
+
+  win.close();
+  await waitFor(win, 'closed');
+}
+
+// ── Test 3: loadFile ────────────────────────────────────────────────────
+
+async function testLoadFile() {
+  console.log('\n3. loadFile: load HTML from disk');
+  const tmpFile = join(tmpdir(), `glimpse-test-${Date.now()}.html`);
+  writeFileSync(tmpFile, `<html><body><script>setTimeout(()=>glimpse.send({loaded:'file'}),500)</script></body></html>`);
+
+  const win = open('<html><body>init</body></html>', { width: 300, height: 200 });
+  await waitFor(win, 'ready');
+
+  win.loadFile(tmpFile);
+  await waitFor(win, 'ready'); // ready fires on new page load
+  const [data] = await waitFor(win, 'message');
+  if (data?.loaded === 'file') pass('loadFile works');
+  else fail(`expected loaded=file, got ${JSON.stringify(data)}`);
+
+  win.close();
+  await waitFor(win, 'closed');
+  try { unlinkSync(tmpFile); } catch {}
+}
+
+// ── Test 4: getInfo ─────────────────────────────────────────────────────
+
+async function testGetInfo() {
+  console.log('\n4. getInfo: request system info');
+  const win = open('<html><body>info test</body></html>', { width: 300, height: 200 });
+  await waitFor(win, 'ready');
+
+  win.getInfo();
+  const [info] = await waitFor(win, 'info');
+  if (info?.screen?.width > 0) pass('info event with screen data');
+  else fail('info missing screen data');
+
+  if (info?.screens?.length > 0) pass('screens array present');
+  else fail('screens array missing');
+
+  win.close();
+  await waitFor(win, 'closed');
+}
+
+// ── Test 5: hidden / show ───────────────────────────────────────────────
+
+async function testHiddenShow() {
+  console.log('\n5. Hidden/show: prewarm mode');
+
+  // Collect messages as they arrive
+  const messages = [];
+  const win = open('<html><body><script>setTimeout(()=>glimpse.send({visible:true}),800)</script></body></html>', {
+    width: 300, height: 200, hidden: true,
+  });
+  win.on('message', (data) => messages.push(data));
+
+  await waitFor(win, 'ready');
+  pass('ready while hidden');
+
+  // Show the window
+  win.show({ title: 'Now Visible' });
+  pass('show() called');
+
+  // Wait for the message if it hasn't arrived yet
+  if (messages.length === 0) await waitFor(win, 'message');
+  if (messages.some(m => m.visible === true)) pass('page script ran');
+  else fail('page script did not send message');
+
+  win.close();
+  await waitFor(win, 'closed');
+}
+
+// ── Test 6: auto-close ─────────────────────────────────────────────────
+
+async function testAutoClose() {
+  console.log('\n6. Auto-close: close after first message');
+  const win = open(
+    '<html><body><script>setTimeout(()=>glimpse.send({auto:true}),500)</script></body></html>',
+    { width: 300, height: 200, autoClose: true }
+  );
+  await waitFor(win, 'ready');
+  pass('ready');
+
+  const [data] = await waitFor(win, 'message');
+  if (data?.auto === true) pass('message received');
+  else fail('unexpected message');
+
+  await waitFor(win, 'closed');
+  pass('auto-closed after message');
+}
+
+// ── Test 7: prompt() helper ─────────────────────────────────────────────
+
+async function testPrompt() {
+  console.log('\n7. prompt(): one-shot helper');
+  const result = await prompt(
+    '<html><body><script>setTimeout(()=>glimpse.send({answer:42}),500)</script></body></html>',
+    { width: 300, height: 200, timeout: 10000 }
+  );
+  if (result?.answer === 42) pass('prompt returned correct data');
+  else fail(`expected answer=42, got ${JSON.stringify(result)}`);
+}
+
+// ── Test 8: window.glimpse.close() from page ────────────────────────────
+
+async function testPageClose() {
+  console.log('\n8. glimpse.close(): close from page JS');
+  const win = open(
+    '<html><body><script>setTimeout(()=>glimpse.close(),500)</script></body></html>',
+    { width: 300, height: 200 }
+  );
+  await waitFor(win, 'ready');
+  pass('ready');
+
+  await waitFor(win, 'closed');
+  pass('closed via glimpse.close()');
+}
+
+// ── Test 9: frameless window ────────────────────────────────────────────
+
+async function testFrameless() {
+  console.log('\n9. Frameless window');
+  const win = open(
+    '<html><body style="background:#222;color:lime;font:20px monospace;padding:20px">frameless<script>setTimeout(()=>glimpse.send({mode:"frameless"}),800)</script></body></html>',
+    { width: 300, height: 150, frameless: true }
+  );
+  await waitFor(win, 'ready');
+  pass('frameless window opened');
+
+  const [data] = await waitFor(win, 'message');
+  if (data?.mode === 'frameless') pass('page working in frameless mode');
+  else fail('page did not work');
+
+  win.close();
+  await waitFor(win, 'closed');
+}
+
+// ── Test 10: floating window ────────────────────────────────────────────
+
+async function testFloating() {
+  console.log('\n10. Floating window (always on top)');
+  const win = open(
+    '<html><body style="background:#003;color:cyan;padding:20px">floating<script>setTimeout(()=>glimpse.send({mode:"floating"}),800)</script></body></html>',
+    { width: 300, height: 150, floating: true }
+  );
+  await waitFor(win, 'ready');
+  pass('floating window opened');
+
+  const [data] = await waitFor(win, 'message');
+  if (data?.mode === 'floating') pass('page working in floating mode');
+  else fail('page did not work');
+
+  win.close();
+  await waitFor(win, 'closed');
+}
+
+// ── Test 11: follow cursor ──────────────────────────────────────────────
+
+async function testFollowCursor() {
+  console.log('\n11. Follow cursor');
+  if (!supportsFollowCursor()) {
+    console.log('  (skipped: follow-cursor not supported on this system)');
+    return;
+  }
+
+  const win = open(
+    '<html><body style="background:rgba(0,0,0,0.8);color:lime;font:14px monospace;padding:10px">following<script>setTimeout(()=>glimpse.send({following:true}),1500)</script></body></html>',
+    { width: 200, height: 80, followCursor: true, frameless: true, floating: true }
+  );
+  await waitFor(win, 'ready');
+  pass('follow-cursor window opened');
+
+  const [data] = await waitFor(win, 'message');
+  if (data?.following === true) pass('page working with follow-cursor');
+  else fail('page did not work');
+
+  // Test runtime toggle
+  win.followCursor(false);
+  await sleep(200);
+  win.followCursor(true, 'top-right');
+  await sleep(500);
+  pass('follow-cursor runtime toggle');
+
+  win.close();
+  await waitFor(win, 'closed');
+}
+
+// ── Test 12: cursorTip ──────────────────────────────────────────────────
+
+async function testCursorTip() {
+  console.log('\n12. Cursor tip');
+  if (!supportsFollowCursor()) {
+    console.log('  (skipped: follow-cursor not supported)');
+    return;
+  }
+
+  const win = open(
+    `<html><body><script>
+      setTimeout(() => {
+        const tip = window.glimpse.cursorTip;
+        glimpse.send({ hasTip: tip !== null, tip });
+      }, 1500);
+    </script></body></html>`,
+    { width: 200, height: 100, followCursor: true, frameless: true, cursorAnchor: 'top-right' }
+  );
+
+  const [readyInfo] = await waitFor(win, 'ready');
+  if (readyInfo?.cursorTip) pass('cursorTip in ready event');
+  else fail('cursorTip missing from ready');
+
+  const [data] = await waitFor(win, 'message');
+  if (data?.hasTip) pass('cursorTip available in page JS');
+  else fail('cursorTip not available in page');
+
+  win.close();
+  await waitFor(win, 'closed');
+}
+
+// ── Test 13: status item (tray) ─────────────────────────────────────────
+
+async function testStatusItem() {
+  console.log('\n13. Status item (system tray)');
+
+  let item;
+  try {
+    item = statusItem(
+      '<html><body style="background:#111;color:#0f0;padding:20px">Tray Content</body></html>',
+      { title: 'GlimpseTest', width: 250, height: 150 }
+    );
+  } catch (e) {
+    fail(`statusItem() threw: ${e.message}`);
+    return;
+  }
+
+  await waitFor(item, 'ready');
+  pass('status item ready');
+
+  // Test setTitle
+  item.setTitle('Updated');
+  await sleep(300);
+  pass('setTitle called');
+
+  // Test resize
+  item.resize(300, 200);
+  await sleep(300);
+  pass('resize called');
+
+  item.close();
+  await waitFor(item, 'closed');
+  pass('status item closed');
+}
+
+// ── Test 14: transparent window ─────────────────────────────────────────
+
+async function testTransparent() {
+  console.log('\n14. Transparent window');
+  const win = open(
+    '<html><body style="background:transparent;color:white;font:20px monospace;padding:20px;text-shadow:0 0 10px cyan">transparent<script>setTimeout(()=>glimpse.send({mode:"transparent"}),800)</script></body></html>',
+    { width: 300, height: 150, transparent: true, frameless: true }
+  );
+  await waitFor(win, 'ready');
+  pass('transparent window opened');
+
+  const [data] = await waitFor(win, 'message');
+  if (data?.mode === 'transparent') pass('page working in transparent mode');
+  else fail('page did not work');
+
+  win.close();
+  await waitFor(win, 'closed');
+}
+
+// ── Test 15: multiple messages ──────────────────────────────────────────
+
+async function testMultipleMessages() {
+  console.log('\n15. Multiple messages');
+  const win = open(`<html><body><script>
+    let i = 0;
+    setInterval(() => { if (i < 3) glimpse.send({i: i++}); }, 200);
+  </script></body></html>`, { width: 300, height: 200 });
+  await waitFor(win, 'ready');
+
+  const messages = [];
+  for (let j = 0; j < 3; j++) {
+    const [data] = await waitFor(win, 'message');
+    messages.push(data);
+  }
+
+  if (messages.length === 3 && messages[2].i === 2) pass('received 3 sequential messages');
+  else fail(`expected 3 messages, got ${messages.length}`);
+
+  win.close();
+  await waitFor(win, 'closed');
+}
+
+// ── Run all tests ───────────────────────────────────────────────────────
+
+async function runAll() {
+  try { await testBasic(); } catch (e) { fail(`Basic: ${e.message}`); }
+  try { await testSetHTML(); } catch (e) { fail(`setHTML: ${e.message}`); }
+  try { await testLoadFile(); } catch (e) { fail(`loadFile: ${e.message}`); }
+  try { await testGetInfo(); } catch (e) { fail(`getInfo: ${e.message}`); }
+  try { await testHiddenShow(); } catch (e) { fail(`hidden/show: ${e.message}`); }
+  try { await testAutoClose(); } catch (e) { fail(`auto-close: ${e.message}`); }
+  try { await testPrompt(); } catch (e) { fail(`prompt: ${e.message}`); }
+  try { await testPageClose(); } catch (e) { fail(`pageClose: ${e.message}`); }
+  try { await testFrameless(); } catch (e) { fail(`frameless: ${e.message}`); }
+  try { await testFloating(); } catch (e) { fail(`floating: ${e.message}`); }
+  try { await testFollowCursor(); } catch (e) { fail(`followCursor: ${e.message}`); }
+  try { await testCursorTip(); } catch (e) { fail(`cursorTip: ${e.message}`); }
+  try { await testStatusItem(); } catch (e) { fail(`statusItem: ${e.message}`); }
+  try { await testTransparent(); } catch (e) { fail(`transparent: ${e.message}`); }
+  try { await testMultipleMessages(); } catch (e) { fail(`multipleMessages: ${e.message}`); }
+
+  console.log(`\n${passed} passed, ${failed} failed`);
+  if (failed > 0) process.exit(1);
+  process.exit(0);
+}
+
+runAll();


### PR DESCRIPTION
New Linux backend that uses system Chromium via CDP pipe instead of WebKitGTK. No Rust, no GTK dev packages, no compile step -- just needs a browser installed.

When the native binary isn't built, Glimpse auto-falls back to spawning `chromium --app --remote-debugging-pipe` and talking CDP over FDs 3/4. A ~1k line Node script (`src/chromium-backend.mjs`) translates between our JSON Lines protocol and CDP. From the caller side nothing changes.

```bash
GLIMPSE_BACKEND=chromium node my-app.mjs  # force it
GLIMPSE_BACKEND=native node my-app.mjs    # force native
# or just don't build the Rust binary and it kicks in automatically
```

This also unlocks stuff the native Linux backend can't do:

- **Follow cursor on X11** (not just Hyprland) -- polls via xdotool, or Hyprland IPC natively via unix socket
- **Status item / system tray** -- tiny inline Python GTK helper, click toggles a window
- **Open links externally** -- intercepts navigations via CDP Fetch, hands off to xdg-open

Window modes work via X11 tooling after the Chrome window appears:
- Frameless: `_MOTIF_WM_HINTS` removal via xprop
- Floating: `_NET_WM_STATE_ABOVE` via xprop  
- Click-through: XFixes empty input shape via python3 ctypes
- Transparent: `Emulation.setDefaultBackgroundColorOverride`