### PR TITLE
fix: include chromium-backend.mjs in npm files array

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
   "files": [
     "src/glimpse.swift",
     "src/glimpse.mjs",
+    "src/chromium-backend.mjs",
     "src/follow-cursor-support.mjs",
     "src/linux/",
     "bin/glimpse.mjs",


### PR DESCRIPTION
PR #8 added src/chromium-backend.mjs but didn't add it to the `files` array in `package.json`
                                                                                                                                            
This causes a runtime crash on Linux when Glimpse falls back to the Chromium CDP backend:                                                
                                                                                                                                                                                                                                                    
Error: Cannot find module '.../glimpseui/src/chromium-backend.mjs'                                                                                                                                                                                                                  