### PR TITLE
feat(companion): CSS drag regions and follow/static modes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## 0.6.2
+
+- **Feature**: CSS drag regions for frameless macOS windows — elements with `--app-region: drag` become draggable window chrome, while `--app-region: no-drag` opt child controls out of dragging. This powers the draggable companion pill while keeping its contents clickable.
+- **Feature**: Companion modes — `/companion follow` and `/companion static` now select between a cursor-following pill and a fixed-position pill. Follow mode is gated by `supportsFollowCursor()` on each platform; static mode works everywhere, with dragging enabled on macOS.
+- **Docs**: Document CSS drag regions and companion modes in README, including cross-platform behavior.
+- **Tests**: Add a regression test to ensure the companion process passes the expected follow/static options through to the native host.
+
 ## 0.6.1
 
 - **Change**: Companion is now hidden by default — enable it with `/companion`. Previously it was shown by default. Existing preferences in `~/.pi/companion.json` are respected.

--- a/README.md
+++ b/README.md
@@ -35,7 +35,12 @@ npm run build:windows    # dotnet publish
 pi install npm:glimpseui
 ```
 
-Installs the Glimpse skill and companion extension for [pi](https://github.com/mariozechner/pi). The companion is a floating status pill that follows your cursor showing what your agents are doing in real-time. It's hidden by default — enable it with the `/companion` command.
+Installs the Glimpse skill and companion extension for [pi](https://github.com/mariozechner/pi). The companion is a floating status pill that shows what your agents are doing in real-time. It supports two modes:
+
+- **follow** — default on platforms with follow-cursor support; the pill follows your cursor near the top-right of the pointer
+- **static** — pins the pill to a fixed position near the top of the main screen (no cursor tracking, works everywhere)
+
+Use `/companion` to toggle the companion, and `/companion follow` or `/companion static` to switch modes. On platforms without follow-cursor support, follow mode is disabled but static mode still works. On macOS, the static pill can also be dragged via CSS drag regions.
 
 ## Quick Start
 
@@ -76,6 +81,28 @@ Common combinations:
 - **Custom dialog**: `frameless: true` — clean UI with no system chrome
 - **Overlay**: `frameless + transparent` — shaped widgets that float over content
 - **Companion widget**: `frameless + transparent + floating + clickThrough` — visual-only overlays that don't interfere with the desktop
+
+### CSS Drag Regions (frameless windows)
+
+On macOS, frameless windows can opt into HTML-defined drag handles using a CSS custom property:
+
+- `--app-region: drag` — the element acts like a title bar; dragging it moves the window
+- `--app-region: no-drag` — opt a subtree out of dragging (e.g. buttons, links)
+
+This is useful for overlay-style UIs where only a specific pill or header should be draggable while the rest of the window remains fully interactive.
+
+Example:
+
+```html
+<body style="margin: 0; background: transparent;">
+  <div id="titlebar" style="--app-region: drag; padding: 8px 12px;">
+    My Glimpse App
+  </div>
+  <button style="--app-region: no-drag">Click me</button>
+</body>
+```
+
+On non-macOS platforms, `--app-region` is ignored and the window behaves like a normal frameless WebView.
 
 ## Follow Cursor
 

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "build:linux": "node scripts/build.mjs linux",
     "build:windows": "node scripts/build.mjs win32",
     "postinstall": "node scripts/postinstall.mjs",
-    "test": "node test/test.mjs && node test/open-links.test.mjs && node test/test-status-item.mjs",
+    "test": "node test/test.mjs && node test/open-links.test.mjs && node test/companion-mode.test.mjs && node test/test-status-item.mjs",
     "test:platform": "node test/platform.mjs",
     "publish:check": "./scripts/publish.sh --dry-run",
     "publish:npm": "./scripts/publish.sh"

--- a/pi-extension/companion.mjs
+++ b/pi-extension/companion.mjs
@@ -70,6 +70,7 @@ body {
   border-radius: 8px;
   padding: 2px 0;
   transition: opacity 0.3s ease-out;
+  --app-region: drag;
 }
 .row {
   display: flex;
@@ -116,6 +117,7 @@ var _rows = {};
 var _startTimes = {};
 var _frozenElapsed = {};
 var _tickTimer = null;
+var _lastSize = { w: 0, h: 0 };
 
 function esc(s) {
   return String(s).replace(/&/g,'&amp;').replace(/</g,'&lt;').replace(/>/g,'&gt;');
@@ -161,11 +163,20 @@ function remove(id) {
   render();
 }
 
+function resizeWindow(width, height) {
+  if (!window.glimpse || typeof window.glimpse.send !== 'function') return;
+  if (width === _lastSize.w && height === _lastSize.h) return;
+  _lastSize.w = width;
+  _lastSize.h = height;
+  window.glimpse.send({ __glimpse_resize: { width: width, height: height } });
+}
+
 function render() {
   var pill = document.getElementById('pill');
   var ids = Object.keys(_rows);
   if (ids.length === 0) {
     pill.style.opacity = '0';
+    resizeWindow(1, 1);
     setTimeout(function() { pill.innerHTML = ''; }, 350);
     return;
   }
@@ -202,6 +213,11 @@ function render() {
     html += '</div>';
   }
   pill.innerHTML = html;
+
+  var rect = pill.getBoundingClientRect();
+  var width = Math.ceil(rect.width);
+  var height = Math.ceil(rect.height);
+  if (width > 0 && height > 0) resizeWindow(width, height);
 }
 </script>
 </body>
@@ -295,17 +311,21 @@ server.listen(SOCK, () => {
 
 // ── window ────────────────────────────────────────────────────────────────────
 
-win = open(buildHTML(), {
+const mode = process.argv.includes('--follow') ? 'follow' : 'static';
+
+const baseOpts = {
   width: 630,
   height: 100,
   frameless: true,
   floating: true,
   transparent: true,
-  clickThrough: true,
-  followCursor: true,
-  followMode: 'spring',
-  cursorAnchor: 'top-right',
-});
+};
+
+const modeOpts = mode === 'follow'
+  ? { clickThrough: true, followCursor: true, followMode: 'spring', cursorAnchor: 'top-right' }
+  : { x: 100, y: 40 };
+
+win = open(buildHTML(), { ...baseOpts, ...modeOpts });
 
 win.on('ready', info => {
   winReady = true;

--- a/pi-extension/index.ts
+++ b/pi-extension/index.ts
@@ -17,28 +17,35 @@ const COMPANION_PATH = join(
 );
 const SETTINGS_PATH = join(homedir(), ".pi", "companion.json");
 
-function loadEnabled(): boolean {
+type CompanionMode = "follow" | "static";
+
+function loadSettings(): { enabled: boolean; mode: CompanionMode } {
   try {
     const data = JSON.parse(readFileSync(SETTINGS_PATH, "utf-8"));
-    return data.enabled === true;
+    return {
+      enabled: data.enabled === true,
+      mode: data.mode === "static" ? "static" : "follow",
+    };
   } catch {
-    return false;
+    return { enabled: false, mode: "follow" };
   }
 }
 
-function saveEnabled(value: boolean) {
+function saveSetting(key: string, value: any) {
   try {
     let data: any = {};
     try {
       data = JSON.parse(readFileSync(SETTINGS_PATH, "utf-8"));
     } catch {}
-    data.enabled = value;
+    data[key] = value;
     writeFileSync(SETTINGS_PATH, JSON.stringify(data, null, 2) + "\n");
   } catch {}
 }
 
 export default function (pi: ExtensionAPI) {
-  let enabled = loadEnabled();
+  const settings = loadSettings();
+  let enabled = settings.enabled;
+  let mode: CompanionMode = settings.mode;
   let sock: Socket | null = null;
   let lastStatus = "";
   let lastCtx: any = null;
@@ -96,7 +103,8 @@ export default function (pi: ExtensionAPI) {
     if (sock) return;
 
     // Spawn companion and retry
-    const child = spawn(process.execPath, [COMPANION_PATH], {
+    const args = [COMPANION_PATH, ...(mode === "follow" ? ["--follow"] : [])];
+    const child = spawn(process.execPath, args, {
       detached: true,
       stdio: "ignore",
       windowsHide: process.platform === "win32",
@@ -124,8 +132,8 @@ export default function (pi: ExtensionAPI) {
 
   async function enable(ctx: any) {
     enabled = true;
-    saveEnabled(true);
-    if (!followCursorSupport.supported) {
+    saveSetting("enabled", true);
+    if (mode === "follow" && !followCursorSupport.supported) {
       maybeNotifyUnsupported(ctx);
       ctx.ui.setStatus("companion", undefined);
       return;
@@ -140,7 +148,7 @@ export default function (pi: ExtensionAPI) {
 
   function disable(ctx: any) {
     enabled = false;
-    saveEnabled(false);
+    saveSetting("enabled", false);
     disconnect();
     ctx.ui.setStatus("companion", undefined);
   }
@@ -156,15 +164,35 @@ export default function (pi: ExtensionAPI) {
   // ── /companion command ────────────────────────────────────────────────────
 
   pi.registerCommand("companion", {
-    description: "Toggle cursor companion (shows agent activity near cursor)",
-    handler: async (_args, ctx) => {
+    description:
+      "Toggle companion or set mode: /companion, /companion follow, /companion static",
+    handler: async (args, ctx) => {
+      const arg = (args ?? "").trim();
+
+      if (arg === "follow" || arg === "static") {
+        const newMode = arg as CompanionMode;
+        if (newMode !== mode) {
+          mode = newMode;
+          saveSetting("mode", mode);
+          // Restart companion with new mode
+          disconnect();
+          if (enabled) {
+            await enable(ctx);
+            ctx.ui.notify(`Companion mode: ${mode}`, "info");
+          }
+        } else {
+          ctx.ui.notify(`Already in ${mode} mode`, "info");
+        }
+        return;
+      }
+
       if (enabled) {
         disable(ctx);
         ctx.ui.notify("Companion disabled", "info");
       } else {
         await enable(ctx);
-        if (followCursorSupport.supported) {
-          ctx.ui.notify("Companion enabled", "info");
+        if (mode === "static" || followCursorSupport.supported) {
+          ctx.ui.notify(`Companion enabled (${mode})`, "info");
         }
       }
     },
@@ -172,15 +200,21 @@ export default function (pi: ExtensionAPI) {
 
   // ── event handlers ────────────────────────────────────────────────────────
 
+  function isActive() {
+    if (!enabled) return false;
+    if (mode === "follow" && !followCursorSupport.supported) return false;
+    return true;
+  }
+
   pi.on("agent_start", async (_event, ctx) => {
-    if (!enabled || !followCursorSupport.supported) return;
+    if (!isActive()) return;
     lastCtx = ctx;
     await ensureConnected();
     send("starting");
   });
 
   pi.on("agent_end", async (_event, ctx) => {
-    if (!enabled || !followCursorSupport.supported) return;
+    if (!isActive()) return;
     lastCtx = ctx;
     send("done");
     setTimeout(() => {
@@ -189,14 +223,14 @@ export default function (pi: ExtensionAPI) {
   });
 
   pi.on("message_update", async (_event, ctx) => {
-    if (!enabled || !followCursorSupport.supported) return;
+    if (!isActive()) return;
     lastCtx = ctx;
     if (lastStatus === "thinking") return;
     send("thinking");
   });
 
   pi.on("tool_execution_start", async (event, ctx) => {
-    if (!enabled || !followCursorSupport.supported) return;
+    if (!isActive()) return;
     lastCtx = ctx;
     const { toolName, args = {} } = event;
 
@@ -222,7 +256,7 @@ export default function (pi: ExtensionAPI) {
   });
 
   pi.on("tool_execution_end", async (event, ctx) => {
-    if (!enabled || !followCursorSupport.supported) return;
+    if (!isActive()) return;
     lastCtx = ctx;
     if (event.isError) {
       send("error", event.toolName);

--- a/src/glimpse.swift
+++ b/src/glimpse.swift
@@ -231,6 +231,19 @@ window.glimpse = {
         window.webkit.messageHandlers.glimpse.postMessage(JSON.stringify({__glimpse_close: true}));
     }
 };
+document.addEventListener('mousedown', function(e) {
+    var el = e.target;
+    while (el && el !== document.documentElement) {
+        var region = getComputedStyle(el).getPropertyValue('--app-region').trim();
+        if (region === 'drag') {
+            e.preventDefault();
+            window.webkit.messageHandlers.glimpse.postMessage(JSON.stringify({__glimpse_drag: true}));
+            return;
+        }
+        if (region === 'no-drag') break;
+        el = el.parentElement;
+    }
+});
 """
 
 // MARK: - Window Subclass (keyboard support for frameless windows)
@@ -238,6 +251,22 @@ window.glimpse = {
 class GlimpsePanel: NSWindow {
     override var canBecomeKey: Bool { true }
     override var canBecomeMain: Bool { true }
+}
+
+// Support CSS --app-region: drag for window dragging
+class DraggableWebView: WKWebView {
+    private var lastMouseDownEvent: NSEvent?
+
+    override func mouseDown(with event: NSEvent) {
+        lastMouseDownEvent = event
+        super.mouseDown(with: event)
+    }
+
+    func startWindowDrag() {
+        guard let event = lastMouseDownEvent, let window = self.window else { return }
+        window.performDrag(with: event)
+        lastMouseDownEvent = nil
+    }
 }
 
 // MARK: - Status Item View Controller
@@ -428,7 +457,7 @@ class AppDelegate: NSObject, NSApplicationDelegate, WKNavigationDelegate, WKScri
     }
 
     private func setupWebView() {
-        webView = WKWebView(frame: window.contentView!.bounds, configuration: makeWebViewConfiguration())
+        webView = DraggableWebView(frame: window.contentView!.bounds, configuration: makeWebViewConfiguration())
         webView.autoresizingMask = [.width, .height]
         webView.navigationDelegate = self
         if config.transparent {
@@ -839,6 +868,20 @@ class AppDelegate: NSObject, NSApplicationDelegate, WKNavigationDelegate, WKScri
 
             if json["__glimpse_close"] as? Bool == true {
                 closeAndExit()
+                return
+            }
+
+            if json["__glimpse_drag"] as? Bool == true {
+                (webView as? DraggableWebView)?.startWindowDrag()
+                return
+            }
+
+            if let resize = json["__glimpse_resize"] as? [String: Any],
+               let width = resize["width"] as? NSNumber,
+               let height = resize["height"] as? NSNumber,
+               width.doubleValue > 0,
+               height.doubleValue > 0 {
+                window.setContentSize(NSSize(width: width.doubleValue, height: height.doubleValue))
                 return
             }
 

--- a/test/companion-mode.test.mjs
+++ b/test/companion-mode.test.mjs
@@ -1,0 +1,136 @@
+import { chmodSync, existsSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { spawn } from 'node:child_process';
+import { supportsFollowCursor } from '../src/follow-cursor-support.mjs';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+
+const TIMEOUT_MS = 10_000;
+
+const tmpDir = mkdtempSync(join(tmpdir(), 'glimpse-companion-mode-'));
+const mockBinary = join(tmpDir, 'glimpse-mock');
+
+console.log('glimpse companion mode regression test');
+
+function pass(msg) {
+  console.log(`  ✓ ${msg}`);
+}
+
+function fail(msg) {
+  console.error(`  ✗ ${msg}`);
+  throw new Error(msg);
+}
+
+function writeMockBinary() {
+  const protocolReady = JSON.stringify({
+    type: 'ready',
+    screen: { width: 800, height: 600, scaleFactor: 1, visibleX: 0, visibleY: 0, visibleWidth: 800, visibleHeight: 600 },
+    screens: [],
+    appearance: { darkMode: false, accentColor: '#000000', reduceMotion: false, increaseContrast: false },
+    cursor: { x: 0, y: 0 },
+  });
+
+  const script = `#!/usr/bin/env node
+const fs = require('node:fs');
+const readline = require('node:readline');
+const argsPath = process.env.GLIMPSE_COMPANION_ARGS_PATH;
+if (argsPath) fs.writeFileSync(argsPath, JSON.stringify(process.argv.slice(2)));
+const protocolReady = ${protocolReady};
+process.stdout.write(protocolReady + '\\n');
+let sentFinalReady = false;
+const rl = readline.createInterface({ input: process.stdin, crlfDelay: Infinity });
+rl.on('line', (line) => {
+  try {
+    const msg = JSON.parse(line);
+    if (msg && msg.type === 'html' && !sentFinalReady) {
+      process.stdout.write(protocolReady + '\\n');
+      sentFinalReady = true;
+    }
+    if (msg && msg.type === 'close') {
+      process.stdout.write(JSON.stringify({ type: 'closed' }) + '\\n');
+      process.exit(0);
+    }
+  } catch {
+    // Ignore malformed JSON from this fixture.
+  }
+});
+`;
+
+  writeFileSync(mockBinary, script);
+  chmodSync(mockBinary, 0o755);
+}
+
+function waitForFile(path, timeoutMs = TIMEOUT_MS) {
+  return new Promise((resolve, reject) => {
+    const start = Date.now();
+    (function poll() {
+      if (existsSync(path)) return resolve();
+      if (Date.now() - start > timeoutMs) {
+        return reject(new Error(`Timeout waiting for file: ${path}`));
+      }
+      setTimeout(poll, 50);
+    })();
+  });
+}
+
+async function collectArgsForMode(mode) {
+  const argsPath = join(tmpDir, `args-${mode}.json`);
+  const companionPath = join(__dirname, '..', 'pi-extension', 'companion.mjs');
+
+  const env = {
+    ...process.env,
+    GLIMPSE_BINARY_PATH: mockBinary,
+    GLIMPSE_COMPANION_ARGS_PATH: argsPath,
+  };
+
+  const childArgs = [companionPath];
+  if (mode === 'follow') childArgs.push('--follow');
+
+  const child = spawn(process.execPath, childArgs, {
+    stdio: 'inherit',
+    env,
+  });
+
+  try {
+    await waitForFile(argsPath);
+  } finally {
+    child.kill('SIGTERM');
+    await new Promise((resolve) => child.on('exit', resolve));
+  }
+
+  return JSON.parse(readFileSync(argsPath, 'utf8'));
+}
+
+try {
+  writeMockBinary();
+
+  const staticArgs = await collectArgsForMode('static');
+  if (staticArgs.includes('--follow-cursor')) {
+    fail('static mode should not pass --follow-cursor');
+  }
+  if (!staticArgs.some((arg) => arg.startsWith('--x=')) || !staticArgs.some((arg) => arg.startsWith('--y='))) {
+    fail('static mode should set a fixed x/y position');
+  }
+  pass('static mode uses fixed-position window without follow-cursor');
+
+  const followArgs = await collectArgsForMode('follow');
+  const followSupported = supportsFollowCursor();
+
+  if (followSupported) {
+    if (!followArgs.includes('--follow-cursor')) {
+      fail('follow mode should pass --follow-cursor when supported');
+    }
+    pass('follow mode enables follow-cursor when supported');
+  } else {
+    if (followArgs.includes('--follow-cursor')) {
+      fail('follow mode should not pass --follow-cursor when follow-cursor is unsupported');
+    }
+    pass('follow mode respects follow-cursor capability gating');
+  }
+
+  console.log('\ncompanion mode tests passed');
+} finally {
+  rmSync(tmpDir, { recursive: true, force: true });
+}


### PR DESCRIPTION
## Summary

https://github.com/user-attachments/assets/87b0fad8-a6e8-4474-ba95-964211b0ff24


Adds two features to support a better companion experience across platforms:

### CSS Drag Regions (macOS)
Elements with `--app-region: drag` become draggable window chrome in frameless mode, while `--app-region: no-drag` opts child controls out. Implemented via a `DraggableWebView` subclass that captures `mouseDown` events and calls `performDrag` on demand.

### Companion Modes
- **follow** — cursor-tracking pill (existing behavior, requires platform support)
- **static** — fixed-position pill with CSS drag regions for repositioning on macOS

The extension exposes `/companion follow` and `/companion static` subcommands and persists the mode preference to `~/.pi/companion.json`.

### Dynamic Window Resize
The companion pill now sends `__glimpse_resize` messages so the native window shrinks/grows to fit content, and collapses to 1×1 when empty.

### Other
- Regression test for companion mode flag passthrough
- README and CHANGELOG updated

## Commits

1. `feat(swift): add CSS drag regions and dynamic window resize`
2. `feat(companion): support follow and static modes`
3. `test: add companion mode regression test`
4. `docs: document CSS drag regions and companion modes`