### PR TITLE
fix: Swift strict concurrency error on macOS 26

### DIFF
--- a/src/glimpse.swift
+++ b/src/glimpse.swift
@@ -622,16 +622,18 @@ class AppDelegate: NSObject, NSApplicationDelegate, WKNavigationDelegate, WKScri
                     log("Skipping invalid JSON: \(trimmed)")
                     continue
                 }
+                let handler = self
                 DispatchQueue.main.async {
                     MainActor.assumeIsolated {
-                        self?.handleCommand(type: type, json: json)
+                        handler?.handleCommand(type: type, json: json)
                     }
                 }
             }
             // stdin EOF — close window
+            let closer = self
             DispatchQueue.main.async {
                 MainActor.assumeIsolated {
-                    self?.closeAndExit()
+                    closer?.closeAndExit()
                 }
             }
         }


### PR DESCRIPTION
Binds weak `self` to local `let` constants before passing into `DispatchQueue.main.async` closures in `startStdinReader()`.

Fixes:
```
src/glimpse.swift:627:25: error: reference to captured var 'self' in concurrently-executing code
src/glimpse.swift:634:21: error: reference to captured var 'self' in concurrently-executing code
```

Reproduces with Swift 5.10 on macOS 26.