### PR TITLE
feat(status-item): add right-click context menu support

### DIFF
--- a/src/glimpse.mjs
+++ b/src/glimpse.mjs
@@ -113,6 +113,9 @@ class GlimpseWindow extends EventEmitter {
         case 'click':
           this.emit('click');
           break;
+        case 'menu':
+          this.emit('menu', msg.id);
+          break;
         case 'closed':
           if (!this.#closed) {
             this.#closed = true;
@@ -255,6 +258,10 @@ export function open(html, options = {}) {
 class GlimpseStatusItem extends GlimpseWindow {
   setTitle(title) {
     this._write({ type: 'title', title });
+  }
+
+  setMenu(items) {
+    this._write({ type: 'status-menu', items });
   }
 
   resize(width, height) {

--- a/src/glimpse.swift
+++ b/src/glimpse.swift
@@ -334,6 +334,7 @@ class AppDelegate: NSObject, NSApplicationDelegate, WKNavigationDelegate, WKScri
     var nsStatusItem: NSStatusItem?
     var popover: NSPopover?
     var popoverViewController: StatusItemViewController?
+    var statusMenu: NSMenu?
 
     nonisolated init(config: Config) {
         self.config = config
@@ -467,6 +468,7 @@ class AppDelegate: NSObject, NSApplicationDelegate, WKNavigationDelegate, WKScri
             button.title = config.title == "Glimpse" ? "G" : config.title
             button.action = #selector(statusItemClicked(_:))
             button.target = self
+            button.sendAction(on: [.leftMouseUp, .rightMouseUp])
         }
 
         // Load blank page to trigger first ready
@@ -475,12 +477,24 @@ class AppDelegate: NSObject, NSApplicationDelegate, WKNavigationDelegate, WKScri
 
     @objc func statusItemClicked(_ sender: Any?) {
         guard let button = nsStatusItem?.button, let popover = popover else { return }
+        if let event = NSApp.currentEvent,
+           (event.type == .rightMouseUp || (event.type == .leftMouseUp && event.modifierFlags.contains(.control))),
+           let statusMenu {
+            NSMenu.popUpContextMenu(statusMenu, with: event, for: button)
+            return
+        }
         if popover.isShown {
             popover.performClose(sender)
         } else {
             popover.show(relativeTo: button.bounds, of: button, preferredEdge: .minY)
         }
         writeToStdout(["type": "click"])
+    }
+
+    @objc func statusMenuItemSelected(_ sender: NSMenuItem) {
+        if let id = sender.representedObject as? String {
+            writeToStdout(["type": "menu", "id": id])
+        }
     }
 
     // MARK: - Follow Cursor
@@ -766,6 +780,23 @@ class AppDelegate: NSObject, NSApplicationDelegate, WKNavigationDelegate, WKScri
             } else {
                 window.setContentSize(size)
             }
+        case "status-menu":
+            guard config.statusItem else {
+                log("status-menu not supported outside status-item mode")
+                return
+            }
+            let items = json["items"] as? [[String: Any]] ?? []
+            let menu = NSMenu()
+            for item in items {
+                guard let id = item["id"] as? String, let title = item["title"] as? String else {
+                    continue
+                }
+                let menuItem = NSMenuItem(title: title, action: #selector(statusMenuItemSelected(_:)), keyEquivalent: "")
+                menuItem.target = self
+                menuItem.representedObject = id
+                menu.addItem(menuItem)
+            }
+            statusMenu = menu.items.isEmpty ? nil : menu
         case "close":
             closeAndExit()
         default:


### PR DESCRIPTION
Closes #16

Add native `NSMenu` support for the status item, enabling right-click / ctrl-click context menus.

### Changes

**Swift (`glimpse.swift`):**
- Add `statusMenu` property on `AppDelegate`
- Handle `rightMouseUp` and `ctrl+leftMouseUp` on the status bar button to pop up the menu via `NSMenu.popUpContextMenu`
- Parse new `status-menu` JSON command (`{"type":"status-menu","items":[{"id":"quit","title":"Quit"}]}`) to dynamically build menu items
- Emit `{"type":"menu","id":"..."}` to stdout when a menu item is selected

**Node wrapper (`glimpse.mjs`):**
- Add `setMenu(items)` method to send the `status-menu` command
- Emit `'menu'` event with the selected item id

### Usage

```js
const win = statusItem(html, { title: 'My Agent' });

win.setMenu([
  { id: 'inspect', title: 'Open Inspector' },
  { id: 'quit', title: 'Quit' },
]);

win.on('menu', (id) => {
  if (id === 'quit') process.exit(0);
});
```

### Testing

Tested with a companion host that uses `setMenu()` to add Quit, Toggle, and Inspector actions — right-click reliably shows the native menu and emits the correct item id.