### PR TITLE
fix: Pass x,y positions in correct format so positioning works

### DIFF
--- a/src/glimpse.mjs
+++ b/src/glimpse.mjs
@@ -236,11 +236,11 @@ export function open(html, options = {}) {
     process.emitWarning(`followCursor disabled: ${reason}`, { code: 'GLIMPSE_FOLLOW_CURSOR_UNSUPPORTED' });
   }
 
-  if (options.x != null) args.push(`--x=${options.x}`);
-  if (options.y != null) args.push(`--y=${options.y}`);
+  if (options.x != null) args.push('--x', String(options.x));
+  if (options.y != null) args.push('--y', String(options.y));
 
-  if (options.cursorOffset?.x != null) args.push(`--cursor-offset-x=${options.cursorOffset.x}`);
-  if (options.cursorOffset?.y != null) args.push(`--cursor-offset-y=${options.cursorOffset.y}`);
+  if (options.cursorOffset?.x != null) args.push('--cursor-offset-x', String(options.cursorOffset.x));
+  if (options.cursorOffset?.y != null) args.push('--cursor-offset-y', String(options.cursorOffset.y));
   if (options.cursorAnchor) args.push('--cursor-anchor', options.cursorAnchor);
   if (options.followMode != null) args.push('--follow-mode', options.followMode);
 


### PR DESCRIPTION
## Problem                                                                                                                                                   
                                                   
When calling `open(html, { x, y })`, the resulting window always appears in the screen center — the `x` and `y` options have no effect.                      
   
   
### Repro                                                                                                                                                     
                                                   
  ```js
  import { open } from 'glimpseui';
  open('<body style="background:red">hi</body>', {
    width: 200, height: 200,                                                                                                                                   
    x: 1000, y: 500,                                                                                                                                           
    frameless: true,                                                                                                                                           
  });
  ```                                                                                                                                                          
                                                   
Expected: window at screen coordinate (1000, 500).                                                                                                           
Actual: window centered on the main screen.      
 
## Root Cause
 
Root cause `src/glimpse.mjs:239-240` uses `--x=${v}` template, but `src/glimpse.swift:165-170` only parses `--x <value>` space-form

Exact same is true for `--cursor-offset-x` as well.

### Verification

Local repro on macOS (Darwin 25.4, Apple Silicon)
