### PR TITLE
fix: replace deleted gtk4-layer-shell git dep with crates.io 0.8.0

### DIFF
--- a/src/linux/Cargo.toml
+++ b/src/linux/Cargo.toml
@@ -10,7 +10,7 @@ path = "src/main.rs"
 [dependencies]
 gtk4 = { version = "0.11", features = ["v4_12"] }
 webkit6 = "0.6"
-gtk4-layer-shell = { git = "https://github.com/haug1/gtk4-layer-shell-gir.git", branch = "chore/gtk4-0.11-unblock-relm4" }
+gtk4-layer-shell = "0.8.0"
 gdk4 = "0.11"
 gdk4-wayland = "0.11"
 gio = "0.22"


### PR DESCRIPTION
## Problem

All Linux installations currently fail during `npm install` because the git dependency references a branch that has been deleted from the remote:

- Branch: `chore/gtk4-0.11-unblock-relm4`
- Repo: `https://github.com/haug1/gtk4-layer-shell-gir.git`

The Cargo build fails with:

```
error: failed to get `gtk4-layer-shell` as a dependency
error: unable to update https://github.com/haug1/gtk4-layer-shell-gir.git
error: failed to update submodule `gir-files`
error: invalid url `git@github.com:gtk-rs/gir-files.git`
```

## Root Cause

The `haug1/gtk4-layer-shell-gir` fork was created to provide gtk4 0.11 support before it landed upstream. That branch is now gone, and the upstream crate has since caught up.

## Solution

Replace the broken git dependency with the stable crates.io release:

```diff
- gtk4-layer-shell = { git = "https://github.com/haug1/gtk4-layer-shell-gir.git", branch = "chore/gtk4-0.11-unblock-relm4" }
+ gtk4-layer-shell = "0.8.0"
```

## Verification

Built and tested on CachyOS Linux (Arch-based):

- Rust 1.95.0
- GTK 4.22.4
- WebKitGTK 2.52.3
- KDE Plasma (Wayland)

`cargo build --release` compiles successfully with zero code changes. The resulting native binary runs correctly.

## Related

Fixes #20
