### PR TITLE
chromium: preserve UTF-8 in HTML data URLs

### DIFF
--- a/src/chromium-backend.mjs
+++ b/src/chromium-backend.mjs
@@ -977,7 +977,7 @@ async function main() {
     switch (msg.type) {
       case 'html': {
         // msg.html is base64 encoded
-        const dataUrl = `data:text/html;base64,${msg.html}`;
+        const dataUrl = `data:text/html;charset=utf-8;base64,${msg.html}`;
         await cdp.send('Page.navigate', { url: dataUrl }, sessionId);
         break;
       }

--- a/test/test-chromium.mjs
+++ b/test/test-chromium.mjs
@@ -79,15 +79,16 @@ async function testSetHTML() {
   await waitFor(win, 'ready');
   pass('first ready');
 
-  // Replace with new HTML
-  win.setHTML('<html><body><div id="x" onclick="glimpse.send({page:2})">page2</div></body></html>');
+  // Replace with new HTML, including non-ASCII text that requires UTF-8 decoding.
+  const expectedText = 'page2 ✕ Close 🚀 Cool!';
+  win.setHTML(`<html><body><div id="x" onclick="glimpse.send({page:2,text:this.textContent})">${expectedText}</div></body></html>`);
   await waitFor(win, 'ready');
   pass('second ready after setHTML');
 
   win.send(`document.getElementById('x').click()`);
   const [data] = await waitFor(win, 'message');
-  if (data?.page === 2) pass('message from new page');
-  else fail(`expected page=2, got ${JSON.stringify(data)}`);
+  if (data?.page === 2 && data?.text === expectedText) pass('message from new page preserves UTF-8 text');
+  else fail(`expected page=2 and text=${JSON.stringify(expectedText)}, got ${JSON.stringify(data)}`);
 
   win.close();
   await waitFor(win, 'closed');


### PR DESCRIPTION
The Chromium CDP backend builds `data:text/html;base64,...` URLs without declaring a charset. Chromium decodes UTF-8 payloads as Windows-1252, so characters render as gibberish (for example, `🚀` becomes `ðŸš€`).

This change declares `charset=utf-8` on the data URL and adds an integration assertion that round-trips `page2 ✕ Close 🚀 Cool!` through `setHTML()`. The Chromium suite passes with 36 tests.
